### PR TITLE
[QCF-62] 유저 페이지 팔로워 / 팔로우 버튼 상세 작업

### DIFF
--- a/desk/src/components/units/user/User.container.tsx
+++ b/desk/src/components/units/user/User.container.tsx
@@ -2,6 +2,13 @@ import { useBoolean } from '@chakra-ui/react'
 import { useCallback, useState } from 'react'
 import { useRouter } from 'next/router'
 import UserUI from './User.presenter'
+import { useAuth } from '@/src/commons/hooks/useAuth'
+
+const TabID = {
+  USER_POSTS: 0,
+  USER_PRODUCT_POSTS: 1,
+  USER_LIKED_POSTS: 2,
+}
 
 export default function User() {
   const router = useRouter()
@@ -12,6 +19,7 @@ export default function User() {
   const [showLikedPosts, setShowLikedPosts] = useState(false)
   // API 받은 후 수정 계획
   const [isMyPage, setIsMyPage] = useState(true)
+  const { isLoggedIn } = useAuth()
 
   const handleShowUserPosts = () => {
     setShowUserPosts(true)
@@ -35,21 +43,22 @@ export default function User() {
   }
 
   const onClickTab = useCallback((id: number) => {
-    if (id === 0) {
+    if (id === TabID.USER_POSTS) {
       handleShowUserPosts()
-    } else if (id === 1) {
+    } else if (id === TabID.USER_PRODUCT_POSTS) {
       handleShowUserProductPosts()
-    } else if (id === 2) {
+    } else if (id === TabID.USER_LIKED_POSTS) {
       handleShowLikedPosts()
     }
   }, [])
 
-  const onClickMoveToAccountEdit = () => {
+  const onClickMoveToAccountEdit = useCallback(() => {
     router.push('/accountEdit')
-  }
+  }, [])
 
   return (
     <UserUI
+      isLoggedIn={isLoggedIn}
       isMyPage={isMyPage}
       isLiked={isLiked}
       toggleIsLiked={toggleIsLiked}

--- a/desk/src/components/units/user/User.presenter.tsx
+++ b/desk/src/components/units/user/User.presenter.tsx
@@ -16,6 +16,7 @@ import { BsLink45Deg } from 'react-icons/bs'
 import { UserUIProps } from './User.types'
 import NavigationTab from './components/tabs'
 import ProductItem from './components/productItem'
+import FollowModal from './components/followModal'
 
 export default function UserUI(props: UserUIProps) {
   return (
@@ -46,6 +47,7 @@ export default function UserUI(props: UserUIProps) {
                 <span style={{ padding: '0 2px' }}>
                   <GoPencil color="dPrimary" />
                 </span>
+                {/* 자신의 페이지일 경우만 보이도록 */}
                 프로필 수정하기
               </Button>
             </Flex>
@@ -69,8 +71,8 @@ export default function UserUI(props: UserUIProps) {
             </Flex>
 
             <Flex position="absolute" bottom="20px" ml="50px" gap="25px">
-              <Button>팔로워 36</Button>
-              <Button>팔로우 136</Button>
+              <FollowModal isLoggedIn={props.isLoggedIn} type="follower" />
+              <FollowModal isLoggedIn={props.isLoggedIn} type="followee" />
             </Flex>
           </Flex>
           <Flex mr="34px" direction="column" justify="center" align="center">

--- a/desk/src/components/units/user/User.types.ts
+++ b/desk/src/components/units/user/User.types.ts
@@ -1,4 +1,5 @@
 export type UserUIProps = {
+  isLoggedIn: boolean
   isMyPage: boolean
   isLiked: boolean
   toggleIsLiked: () => void

--- a/desk/src/components/units/user/components/followModal/FollowModal.types.ts
+++ b/desk/src/components/units/user/components/followModal/FollowModal.types.ts
@@ -1,0 +1,6 @@
+export type FollowModalType = 'follower' | 'followee'
+
+export type FollowModalProps = {
+  isLoggedIn: boolean
+  type: FollowModalType
+}

--- a/desk/src/components/units/user/components/followModal/index.tsx
+++ b/desk/src/components/units/user/components/followModal/index.tsx
@@ -20,6 +20,8 @@ import {
   Avatar,
 } from '@chakra-ui/react'
 import { MdPersonOutline } from 'react-icons/md'
+import { FollowModalProps } from './FollowModal.types'
+import { useAuth } from '@/src/commons/hooks/useAuth'
 
 // 테스트용 FOLLOWERS API 연결 후 삭제 예정
 const FOLLOWERS = [
@@ -61,18 +63,31 @@ const FOLLOWERS = [
   },
 ]
 
-export default function FollowModal() {
+export default function FollowModal(props: FollowModalProps) {
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const { openModal } = useAuth()
+
+  const onClickModalButton = () => {
+    if (props.isLoggedIn) {
+      // 비 로그인 시 로그인 창 오픈
+      openModal('LOGIN')
+    } else {
+      // 로그인 시 팔로워/팔로우 모달 창 오픈
+      onOpen()
+    }
+  }
 
   return (
     <>
-      <Button onClick={onOpen}>팔로워/팔로우에 연결 예정</Button>
+      <Button onClick={() => onClickModalButton()}>
+        {props.type === 'follower' ? '팔로워' : '팔로우'}
+      </Button>
 
       <Modal onClose={onClose} size="md" isOpen={isOpen} isCentered>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader mx="auto" p="12px">
-            팔로워
+            {props.type === 'follower' ? '팔로워' : '팔로우'}
           </ModalHeader>
           <ModalCloseButton />
           <Divider />
@@ -107,92 +122,6 @@ export default function FollowModal() {
                     </CardBody>
                   </Card>
                 ))}
-
-                {/* ============= */}
-                {/* <Card w="100%" variant="elevated" px="10px">
-                  <CardBody p="0px">
-                    <Flex py="6px" justify="space-between" align="center">
-                      <Flex align="center">
-                        <Avatar
-                          mr="10px"
-                          name="Dan Abrahmov"
-                          src="https://bit.ly/dan-abramov"
-                        />
-                        <VStack align="flex-start">
-                          <Text fontSize="14px" fontWeight="600">
-                            Alice
-                          </Text>
-                          <Text fontSize="12px">45 Connections</Text>
-                        </VStack>
-                      </Flex>
-                      <IconButton
-                        variant="outline"
-                        bgColor="dPrimary"
-                        color="white"
-                        aria-label="follow"
-                        fontSize="25px"
-                        icon={<MdPersonOutline />}
-                      />
-                    </Flex>
-                  </CardBody>
-                </Card>
-                <Card w="100%" variant="elevated" px="10px">
-                  <CardBody p="0px">
-                    <Flex py="6px" justify="space-between" align="center">
-                      <Flex align="center">
-                        <Avatar
-                          mr="10px"
-                          name="Dan Abrahmov"
-                          src="https://bit.ly/dan-abramov"
-                        />
-                        <VStack align="flex-start">
-                          <Text fontSize="14px" fontWeight="600">
-                            Alice
-                          </Text>
-                          <Text fontSize="12px">45 Connections</Text>
-                        </VStack>
-                      </Flex>
-                      <IconButton
-                        variant="outline"
-                        color="dPrimary"
-                        bg="white"
-                        borderColor="dPrimary"
-                        border="2px"
-                        aria-label="follow"
-                        fontSize="25px"
-                        icon={<MdPersonOutline />}
-                      />
-                    </Flex>
-                  </CardBody>
-                </Card>
-                <Card w="100%" variant="elevated" px="10px">
-                  <CardBody p="0px">
-                    <Flex py="6px" justify="space-between" align="center">
-                      <Flex align="center">
-                        <Avatar
-                          mr="10px"
-                          name="Dan Abrahmov"
-                          src="https://bit.ly/dan-abramov"
-                        />
-                        <VStack align="flex-start">
-                          <Text fontSize="14px" fontWeight="600">
-                            Alice
-                          </Text>
-                          <Text fontSize="12px">45 Connections</Text>
-                        </VStack>
-                      </Flex>
-                      <IconButton
-                        variant="outline"
-                        bgColor="dPrimary"
-                        color="white"
-                        aria-label="follow"
-                        fontSize="25px"
-                        icon={<MdPersonOutline />}
-                      />
-                    </Flex>
-                  </CardBody>
-                </Card> */}
-                {/* ============= */}
               </VStack>
             </InfiniteScroller>
           </ModalBody>


### PR DESCRIPTION
## 작업사항
- 유저 페이지 팔로워 / 팔로우 버튼 상세 작업
     - 비로그인시 팔로워/팔로우 버튼 클릭 시 로그인 모달 띄우기
     - 로그인 시 팔로워/팔로우 버튼 클릭 시 팔로워/팔로우 모달 띄우기

## 추가 작업 사항
- 팔로워/팔로우 API 붙이기
- 팔로워/팔로우 모달창 내에 무한스크롤 버그 수정   