### PR TITLE
[QCF-60] 최신게시물 카테고리 / 더보기 api 연결

### DIFF
--- a/desk/next.config.js
+++ b/desk/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['i.ytimg.com'],
+    domains: ['i.ytimg.com', 'storage.googleapis.com'],
   },
 }
 

--- a/desk/src/components/ui/logo/index.tsx
+++ b/desk/src/components/ui/logo/index.tsx
@@ -20,7 +20,7 @@ export default function Logo(props: LogoProps) {
         color="dPrimary"
         cursor="pointer"
         onClick={onClickMoveToMain}>
-        dechaive
+        dechive
         <Text
           as="b"
           fontSize="50px"

--- a/desk/src/components/ui/mainImageStyle/types.ts
+++ b/desk/src/components/ui/mainImageStyle/types.ts
@@ -1,4 +1,4 @@
 export type MainImageStyleProps = {
   src: string
-  alt: string
+  alt?: string
 }

--- a/desk/src/components/units/main/categories/recent/Recent.container.tsx
+++ b/desk/src/components/units/main/categories/recent/Recent.container.tsx
@@ -15,7 +15,7 @@ export default function Recent() {
     return <ErrorMessage message={error.message} />
   }
 
-  const boards = data?.fetchBoards || []
+  const boards = data?.fetchBoards ?? []
 
   // const images = boards.map(
   //   board => board.pictures.find((picture: TPicture) => picture.isMain)?.url ?? '',

--- a/desk/src/components/units/main/categories/recent/Recent.container.tsx
+++ b/desk/src/components/units/main/categories/recent/Recent.container.tsx
@@ -1,9 +1,29 @@
 import RecentUI from './Recent.presenter'
+import { useQuery } from '@apollo/client'
+import { TPicture, TQuery } from '@/src/commons/types/generated/types'
+import { FETCH_BOARDS } from './Recent.queries'
+import CustomSpinner from '@/src/components/ui/spinner'
+import ErrorMessage from '@/src/components/ui/errorMessage'
 
 export default function Recent() {
+  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS)
+
+  if (loading) {
+    return <CustomSpinner />
+  }
+  if (error) {
+    return <ErrorMessage message={error.message} />
+  }
+
+  const boards = data?.fetchBoards || []
+
+  // const images = boards.map(
+  //   board => board.pictures.find((picture: TPicture) => picture.isMain)?.url ?? '',
+  // )
+
   return (
     <>
-      <RecentUI />
+      <RecentUI boards={boards} />
     </>
   )
 }

--- a/desk/src/components/units/main/categories/recent/Recent.presenter.tsx
+++ b/desk/src/components/units/main/categories/recent/Recent.presenter.tsx
@@ -1,20 +1,13 @@
 import { Center } from '@chakra-ui/react'
 import CategoryHeader from '../../components/categoryHeader/CategoryHeader.container'
 import MainBoardSlider from '../../components/mainBoardSlider'
+import { RecentUIProps } from './Recent.types'
 
-export default function RecentUI() {
+export default function RecentUI(props: RecentUIProps) {
   const categoryTitle = '⏱️ 최근 게시물'
-  // api 연결 예정 - UI 테스트를 위한 이미지값
-  const images = [
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-    '/test1.jpeg',
-  ]
+  const images = props.boards.map(
+    board => board.pictures.find(picture => picture.isMain)?.url ?? '',
+  )
 
   return (
     <>

--- a/desk/src/components/units/main/categories/recent/Recent.queries.ts
+++ b/desk/src/components/units/main/categories/recent/Recent.queries.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client'
+
+export const FETCH_BOARDS = gql`
+  query fetchBoards {
+    fetchBoards {
+      id
+      title
+      pictures {
+        url
+        isMain
+      }
+      hashtags {
+        id
+        hashtag
+      }
+      writer {
+        nickName
+        picture
+        jobGroup
+      }
+      createdAt
+      views
+      likes
+    }
+  }
+`

--- a/desk/src/components/units/main/categories/recent/Recent.types.ts
+++ b/desk/src/components/units/main/categories/recent/Recent.types.ts
@@ -1,0 +1,5 @@
+import { TBoard } from '@/src/commons/types/generated/types'
+
+export type RecentUIProps = {
+  boards: TBoard[]
+}

--- a/desk/src/components/units/main/components/mainBoardSlider/index.tsx
+++ b/desk/src/components/units/main/components/mainBoardSlider/index.tsx
@@ -54,7 +54,6 @@ export default function MainBoardSlider({ images, children }: MainBoardSliderPro
         aria-label="right-arrow"
         variant="ghost"
         position="absolute"
-        zIndex={2}
         top="40%"
         right={arrowRightPosition}
         onClick={onClickNext}

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
@@ -1,13 +1,29 @@
+import { useQuery } from '@apollo/client'
+import { TQuery } from '@/src/commons/types/generated/types'
+import { FETCH_BOARDS } from './RecentMore.queries'
 import RecentMoreUI from './RecentMore.presenter'
+import CustomSpinner from '@/src/components/ui/spinner'
+import ErrorMessage from '@/src/components/ui/errorMessage'
 
 export default function RecentMore() {
+  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS)
+
+  if (loading) {
+    return <CustomSpinner />
+  }
+  if (error) {
+    return <ErrorMessage message={error.message} />
+  }
+
+  const boards = data?.fetchBoards || []
+
   const handleOnLoadMore = () => {
     console.log('더보기')
   }
 
   return (
     <>
-      <RecentMoreUI onLoadMore={handleOnLoadMore} />
+      <RecentMoreUI onLoadMore={handleOnLoadMore} boards={boards} />
     </>
   )
 }

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
@@ -15,7 +15,7 @@ export default function RecentMore() {
     return <ErrorMessage message={error.message} />
   }
 
-  const boards = data?.fetchBoards || []
+  const boards = data?.fetchBoards ?? []
 
   const handleOnLoadMore = () => {
     console.log('더보기')

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
@@ -1,4 +1,12 @@
-import { Center, Container, Flex, Text, useColorModeValue } from '@chakra-ui/react'
+import {
+  Avatar,
+  Box,
+  Center,
+  Container,
+  Flex,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react'
 import { RecentMoreUIProps } from './RecentMore.types'
 import MainImageStyle from '@/src/components/ui/mainImageStyle'
 import InfiniteScroll from 'react-infinite-scroller'
@@ -7,7 +15,7 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
   return (
     <>
       <Container
-        maxW="1200px"
+        maxW="1170px"
         h="900px"
         mt="50px"
         overflow="auto"
@@ -19,7 +27,7 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
           'scrollbar-width': 'none',
         }}>
         <Text
-          ml="40px"
+          ml="30px"
           fontSize="18pt"
           fontWeight="700"
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
@@ -31,10 +39,39 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
           hasMore={true}
           useWindow={false}>
           <Flex flexWrap="wrap" justifyContent="center" m={2}>
-            {Array.from({ length: 100 }).map((_, index) => (
-              <Center key={index} m={'15px'}>
-                <MainImageStyle src={`/test1.jpeg`} alt={`test image1`} />
-              </Center>
+            {props.boards.map((board, index) => (
+              <Box
+                key={index}
+                m={'15px'}
+                maxW={{ base: '100%', md: '25%' }}
+                textAlign="center">
+                <MainImageStyle
+                  src={board.pictures.find(picture => picture.isMain)?.url ?? ''}
+                  alt={`test image${index}`}
+                />
+                <Text fontSize="13pt" fontWeight="bold" mt={2}>
+                  {board.title}
+                </Text>
+                <Center>
+                  <Text fontSize="11pt" mt={2}>
+                    <Avatar
+                      // size={'xs'}
+                      w="20px"
+                      h="20px"
+                      mr="5px"
+                    />
+                    {board.writer.nickName}
+                  </Text>
+                </Center>
+                {board.hashtags && (
+                  <Text fontSize="sm" mt={2}>
+                    {board.hashtags.map(hashtag => `#${hashtag.hashtag}`).join(' ')}
+                  </Text>
+                )}
+                <Text fontSize="sm" mt={1} color="dGray.dark">
+                  {`조회수: ${board.views}`}
+                </Text>
+              </Box>
             ))}
           </Flex>
         </InfiniteScroll>

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
@@ -49,8 +49,15 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                   src={board.pictures.find(picture => picture.isMain)?.url ?? ''}
                   alt={`test image${index}`}
                 />
-                <Text fontSize="13pt" fontWeight="bold" mt={2}>
-                  {board.title}
+                <Text
+                  w="235px"
+                  ml="5px"
+                  noOfLines={2}
+                  fontSize="13pt"
+                  fontWeight="bold"
+                  mt={2}>
+                  {board.title.substring(0, 28)}
+                  {board.title.length > 28 ? '...' : ''}
                 </Text>
                 <Center>
                   <Text fontSize="11pt" mt={2}>
@@ -63,11 +70,12 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                     {board.writer.nickName}
                   </Text>
                 </Center>
-                {board.hashtags && (
+                {/* 해시태그 */}
+                {/* {board.hashtags && (
                   <Text fontSize="sm" mt={2}>
-                    {board.hashtags.map(hashtag => `#${hashtag.hashtag}`).join(' ')}
+                    {board.hashtags.map(hashtag => `${hashtag.hashtag}`).join(' ')}
                   </Text>
-                )}
+                )} */}
                 <Text fontSize="sm" mt={1} color="dGray.dark">
                   {`조회수: ${board.views}`}
                 </Text>

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.queries.ts
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.queries.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client'
+
+export const FETCH_BOARDS = gql`
+  query fetchBoards {
+    fetchBoards {
+      id
+      title
+      pictures {
+        url
+        isMain
+      }
+      hashtags {
+        id
+        hashtag
+      }
+      writer {
+        nickName
+        picture
+        jobGroup
+      }
+      createdAt
+      views
+      likes
+    }
+  }
+`

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.types.ts
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.types.ts
@@ -1,3 +1,6 @@
+import { TBoard } from '@/src/commons/types/generated/types'
+
 export type RecentMoreUIProps = {
   onLoadMore: () => void
+  boards: TBoard[]
 }


### PR DESCRIPTION
### 작업사항
- 최근게시물 메인페이지 카테고리 / 더보기페이지 fetchBoards api 연결
- FETCH_BOARDS queries 생성 / 타입 수정
- 게시물 이미지 - 도메인 추가

### 수정사항
- slider 화살표 UI 버그 수정
- 최근게시물 더보기 - 글자 수 제한 / 해시태그 제거
- 로고 수정