### PR TITLE
[QCF-48] 모바일 반응형 처리 / api 수정사항 업데이트

### DIFF
--- a/desk/src/commons/hooks/useAuth.tsx
+++ b/desk/src/commons/hooks/useAuth.tsx
@@ -53,7 +53,6 @@ export function useAuth() {
 
   /** 유저 정보 */
   useEffect(() => {
-    setIsLoggedIn(true)
     void fetchUserInfo()
   }, [myToken])
 
@@ -134,6 +133,7 @@ export function useAuth() {
       })
 
       setMyUserInfo(result.data.fetchLoginUser)
+      setIsLoggedIn(true)
     }
   }
 

--- a/desk/src/commons/types/generated/types.ts
+++ b/desk/src/commons/types/generated/types.ts
@@ -1,361 +1,376 @@
-export type Maybe<T> = T | null
-export type InputMaybe<T> = Maybe<T>
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>
-}
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>
-}
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string
-  String: string
-  Boolean: boolean
-  Int: number
-  Float: number
-  DateTime: any
-  Upload: any
-}
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  DateTime: any;
+  Upload: any;
+};
 
 export type TAuthEmailInput = {
-  authCheck: Scalars['Boolean']
-  email: Scalars['String']
-}
+  authCheck: Scalars['Boolean'];
+  email: Scalars['String'];
+};
 
 export type TBoard = {
-  __typename?: 'Board'
-  comments?: Maybe<Array<TComments>>
-  createdAt: Scalars['DateTime']
-  description: Scalars['String']
-  hashtags?: Maybe<Array<THashtag>>
-  id: Scalars['String']
-  like: Scalars['Boolean']
-  likers?: Maybe<Array<TUser>>
-  likes: Scalars['Int']
-  pictures: Array<TPicture>
-  products: Array<TProduct>
-  recommend?: Maybe<Scalars['String']>
-  title: Scalars['String']
-  views: Scalars['Int']
-  writer: TUser
-}
+  __typename?: 'Board';
+  comments?: Maybe<Array<TComments>>;
+  createdAt: Scalars['DateTime'];
+  description: Scalars['String'];
+  hashtags?: Maybe<Array<THashtag>>;
+  id: Scalars['String'];
+  like: Scalars['Boolean'];
+  likers?: Maybe<Array<TUser>>;
+  likes: Scalars['Int'];
+  pictures: Array<TPicture>;
+  products: Array<TProduct>;
+  recommend?: Maybe<Scalars['String']>;
+  title: Scalars['String'];
+  views: Scalars['Int'];
+  writer: TUser;
+};
 
 export type TComments = {
-  __typename?: 'Comments'
-  board: TBoard
-  content: Scalars['String']
-  createdAt?: Maybe<Scalars['DateTime']>
-  id: Scalars['String']
-  replies?: Maybe<Array<TReply>>
-  user: TUser
-}
+  __typename?: 'Comments';
+  board: TBoard;
+  content: Scalars['String'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String'];
+  replies?: Maybe<Array<TReply>>;
+  user: TUser;
+};
 
 export type TCreateBoardInput = {
-  createProductInputs: Array<TCreateProductInput>
-  description: Scalars['String']
-  hashtags?: InputMaybe<Array<Scalars['String']>>
-  recommend?: InputMaybe<Scalars['String']>
-  title: Scalars['String']
-  uploadFile: Array<Scalars['String']>
-}
+  createProductInputs: Array<TCreateProductInput>;
+  description: Scalars['String'];
+  hashtags?: InputMaybe<Array<Scalars['String']>>;
+  recommend?: InputMaybe<Scalars['String']>;
+  title: Scalars['String'];
+  uploadFile: Array<Scalars['String']>;
+};
 
 export type TCreateCommentInput = {
-  boardid: Scalars['String']
-  content: Scalars['String']
-}
+  boardid: Scalars['String'];
+  content: Scalars['String'];
+};
 
 export type TCreateProductInput = {
-  description?: InputMaybe<Scalars['String']>
-  imageUrl?: InputMaybe<Scalars['String']>
-  name?: InputMaybe<Scalars['String']>
-  url?: InputMaybe<Scalars['String']>
-}
+  description?: InputMaybe<Scalars['String']>;
+  imageUrl?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
 
 export type TCreateReplyInput = {
-  commentid: Scalars['String']
-  content: Scalars['String']
-}
+  commentid: Scalars['String'];
+  content: Scalars['String'];
+};
 
 export type TCreateUserInput = {
-  email: Scalars['String']
-  jobGroup: Scalars['String']
-  password: Scalars['String']
-  provider?: InputMaybe<Scalars['String']>
-}
+  email: Scalars['String'];
+  jobGroup: Scalars['String'];
+  password: Scalars['String'];
+  provider?: InputMaybe<Scalars['String']>;
+};
 
 export type TFetchUser = {
-  __typename?: 'FetchUser'
-  boardCount: Scalars['Int']
-  user: TUser
-}
-
-export type TFollowing = {
-  __typename?: 'Following'
-  followingid: Scalars['String']
-  id: Scalars['String']
-  users: Array<TUser>
-}
+  __typename?: 'FetchUser';
+  boardCount: Scalars['Int'];
+  user: TUser;
+};
 
 export type THashtag = {
-  __typename?: 'Hashtag'
-  boards: Array<TBoard>
-  hashtag: Scalars['String']
-  id: Scalars['String']
-}
+  __typename?: 'Hashtag';
+  boards: Array<TBoard>;
+  hashtag: Scalars['String'];
+  id: Scalars['String'];
+};
 
 export type TLoginInput = {
-  email: Scalars['String']
-  password: Scalars['String']
-}
+  email: Scalars['String'];
+  password: Scalars['String'];
+};
 
 export type TMatchAuthInput = {
-  authNumber: Scalars['String']
-  email: Scalars['String']
-}
+  authNumber: Scalars['String'];
+  email: Scalars['String'];
+};
 
 export type TMutation = {
-  __typename?: 'Mutation'
-  authEmail: Scalars['Boolean']
-  createBoard: TBoard
-  createComment: TComments
-  createReply: TReply
-  createUser: TUser
-  deleteBoard: Scalars['Boolean']
-  deleteComment: Scalars['Boolean']
-  deleteReply: Scalars['Boolean']
-  deleteUser: Scalars['Boolean']
-  logOut: Scalars['String']
-  login: Scalars['String']
-  matchAuthNumber: Scalars['Boolean']
-  resetUserPassword: Scalars['Boolean']
-  restoreAccessToken: Scalars['String']
-  updateBoard: TBoard
-  updateBoardLiker: Scalars['Boolean']
-  updateFollowing: Scalars['Boolean']
-  updateUser: TUser
-  uploadFile: Array<Scalars['String']>
-}
+  __typename?: 'Mutation';
+  authEmail: Scalars['Boolean'];
+  createBoard: TBoard;
+  createComment: TComments;
+  createReply: TReply;
+  createUser: TUser;
+  deleteBoard: Scalars['Boolean'];
+  deleteComment: Scalars['Boolean'];
+  deleteReply: Scalars['Boolean'];
+  deleteUser: Scalars['Boolean'];
+  logOut: Scalars['String'];
+  login: Scalars['String'];
+  matchAuthNumber: Scalars['Boolean'];
+  resetUserPassword: Scalars['Boolean'];
+  restoreAccessToken: Scalars['String'];
+  updateBoard: TBoard;
+  updateBoardLiker: Scalars['Boolean'];
+  updateFollowing: Scalars['Boolean'];
+  updateUser: TUser;
+  uploadFile: Array<Scalars['String']>;
+};
+
 
 export type TMutationAuthEmailArgs = {
-  authEmailInput: TAuthEmailInput
-}
+  authEmailInput: TAuthEmailInput;
+};
+
 
 export type TMutationCreateBoardArgs = {
-  createBoardInput: TCreateBoardInput
-}
+  createBoardInput: TCreateBoardInput;
+};
+
 
 export type TMutationCreateCommentArgs = {
-  createCommentInput: TCreateCommentInput
-}
+  createCommentInput: TCreateCommentInput;
+};
+
 
 export type TMutationCreateReplyArgs = {
-  createReplyInput: TCreateReplyInput
-}
+  createReplyInput: TCreateReplyInput;
+};
+
 
 export type TMutationCreateUserArgs = {
-  createUserInput: TCreateUserInput
-}
+  createUserInput: TCreateUserInput;
+};
+
 
 export type TMutationDeleteBoardArgs = {
-  boardid: Scalars['String']
-}
+  boardid: Scalars['String'];
+};
+
 
 export type TMutationDeleteCommentArgs = {
-  commentid: Scalars['String']
-}
+  commentid: Scalars['String'];
+};
+
 
 export type TMutationDeleteReplyArgs = {
-  replyid: Scalars['String']
-}
+  replyid: Scalars['String'];
+};
+
 
 export type TMutationLoginArgs = {
-  loginInput: TLoginInput
-}
+  loginInput: TLoginInput;
+};
+
 
 export type TMutationMatchAuthNumberArgs = {
-  matchAuthInput: TMatchAuthInput
-}
+  matchAuthInput: TMatchAuthInput;
+};
+
 
 export type TMutationResetUserPasswordArgs = {
-  resetPasswordInput: TResetPasswordInput
-}
+  resetPasswordInput: TResetPasswordInput;
+};
+
 
 export type TMutationUpdateBoardArgs = {
-  boardid: Scalars['String']
-  updateBoardInput: TUpdateBoardInput
-}
+  boardid: Scalars['String'];
+  updateBoardInput: TUpdateBoardInput;
+};
+
 
 export type TMutationUpdateBoardLikerArgs = {
-  boardid: Scalars['String']
-}
+  boardid: Scalars['String'];
+};
+
 
 export type TMutationUpdateFollowingArgs = {
-  followingid: Scalars['String']
-}
+  followingid: Scalars['String'];
+};
+
 
 export type TMutationUpdateUserArgs = {
-  updateUserInput: TUpdateUserInput
-}
+  updateUserInput: TUpdateUserInput;
+};
+
 
 export type TMutationUploadFileArgs = {
-  files: Array<Scalars['Upload']>
-}
+  files: Array<Scalars['Upload']>;
+};
 
 export type TOpenGraph = {
-  __typename?: 'OpenGraph'
-  description?: Maybe<Scalars['String']>
-  imageUrl?: Maybe<Scalars['String']>
-  name?: Maybe<Scalars['String']>
-  url?: Maybe<Scalars['String']>
-}
+  __typename?: 'OpenGraph';
+  description?: Maybe<Scalars['String']>;
+  imageUrl?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+};
 
 export type TPicture = {
-  __typename?: 'Picture'
-  board: TBoard
-  id: Scalars['String']
-  isMain: Scalars['Boolean']
-  url: Scalars['String']
-}
+  __typename?: 'Picture';
+  board: TBoard;
+  id: Scalars['String'];
+  isMain: Scalars['Boolean'];
+  url: Scalars['String'];
+};
 
 export type TProduct = {
-  __typename?: 'Product'
-  board: TBoard
-  description?: Maybe<Scalars['String']>
-  id: Scalars['String']
-  name?: Maybe<Scalars['String']>
-  picture?: Maybe<Scalars['String']>
-  url: Scalars['String']
-}
+  __typename?: 'Product';
+  board: TBoard;
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  picture?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
 
 export type TQuery = {
-  __typename?: 'Query'
-  fetchAllProducts: Array<TProduct>
-  fetchBoard: TBoard
-  fetchBoards: Array<TBoard>
-  fetchBoardsUserLiked: Array<TBoard>
-  fetchFollowees: Array<TUser>
-  fetchFollowingBoards: Array<TFollowing>
-  fetchFollowings: Array<TUser>
-  fetchLoginUser: TUser
-  fetchTop10: Array<TBoard>
-  fetchUser: TFetchUser
-  fetchUserBoards: Array<TBoard>
-  fetchUserProducts: Array<TProduct>
-  fetchYoutube: Array<TYoutube>
-  getOpenGraph: TOpenGraph
-  searchBoards: Array<TBoard>
-}
+  __typename?: 'Query';
+  fetchAllProducts: Array<TProduct>;
+  fetchBoard: TBoard;
+  fetchBoards: Array<TBoard>;
+  fetchBoardsUserLiked: Array<TBoard>;
+  fetchFollowees: Array<TUser>;
+  fetchFollowingBoards: Array<TUser>;
+  fetchFollowings: Array<TUser>;
+  fetchLoginUser: TUser;
+  fetchTop10: Array<TBoard>;
+  fetchUser: TFetchUser;
+  fetchUserBoards: Array<TBoard>;
+  fetchUserProducts: Array<TProduct>;
+  fetchYoutube: Array<TYoutube>;
+  getOpenGraph: TOpenGraph;
+  searchBoards: Array<TBoard>;
+};
+
 
 export type TQueryFetchBoardArgs = {
-  boardid: Scalars['String']
-  userid: Scalars['String']
-}
+  boardid: Scalars['String'];
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchBoardsArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchFolloweesArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchFollowingsArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchTop10Args = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchUserArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchUserBoardsArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryFetchUserProductsArgs = {
-  userid: Scalars['String']
-}
+  userid: Scalars['String'];
+};
+
 
 export type TQueryGetOpenGraphArgs = {
-  url: Scalars['String']
-}
+  url: Scalars['String'];
+};
+
 
 export type TQuerySearchBoardsArgs = {
-  keyword: Scalars['String']
-}
+  keyword: Scalars['String'];
+};
 
 export type TReply = {
-  __typename?: 'Reply'
-  comment: TComments
-  content: Scalars['String']
-  createdAt: Scalars['DateTime']
-  id: Scalars['String']
-  user: TUser
-}
+  __typename?: 'Reply';
+  comment: TComments;
+  content: Scalars['String'];
+  createdAt: Scalars['DateTime'];
+  id: Scalars['String'];
+  user: TUser;
+};
 
 export type TResetPasswordInput = {
-  email: Scalars['String']
-  password: Scalars['String']
-}
+  email: Scalars['String'];
+  password: Scalars['String'];
+};
 
 export type TSnsAccount = {
-  __typename?: 'SnsAccount'
-  id: Scalars['String']
-  sns: Scalars['String']
-  user: TUser
-}
+  __typename?: 'SnsAccount';
+  id: Scalars['String'];
+  sns: Scalars['String'];
+  user: TUser;
+};
 
 export type TUpdateBoardInput = {
-  description: Scalars['String']
-  hashtags?: InputMaybe<Array<Scalars['String']>>
-  recommend?: InputMaybe<Scalars['String']>
-  title: Scalars['String']
-  updateProductInputs: Array<TUpdateProductInput>
-  uploadFile: Array<Scalars['String']>
-}
+  description: Scalars['String'];
+  hashtags?: InputMaybe<Array<Scalars['String']>>;
+  recommend?: InputMaybe<Scalars['String']>;
+  title: Scalars['String'];
+  updateProductInputs: Array<TUpdateProductInput>;
+  uploadFile: Array<Scalars['String']>;
+};
 
 export type TUpdateProductInput = {
-  description?: InputMaybe<Scalars['String']>
-  imageUrl?: InputMaybe<Scalars['String']>
-  name?: InputMaybe<Scalars['String']>
-  picture?: InputMaybe<Scalars['String']>
-  url?: InputMaybe<Scalars['String']>
-}
+  description?: InputMaybe<Scalars['String']>;
+  imageUrl?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  picture?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
 
 export type TUpdateUserInput = {
-  intro?: InputMaybe<Scalars['String']>
-  jobGroup?: InputMaybe<Scalars['String']>
-  nickName?: InputMaybe<Scalars['String']>
-  picture?: InputMaybe<Scalars['String']>
-  snsAccount?: InputMaybe<Array<Scalars['String']>>
-}
+  intro?: InputMaybe<Scalars['String']>;
+  jobGroup?: InputMaybe<Scalars['String']>;
+  nickName?: InputMaybe<Scalars['String']>;
+  picture?: InputMaybe<Scalars['String']>;
+  snsAccount?: InputMaybe<Array<Scalars['String']>>;
+};
 
 export type TUser = {
-  __typename?: 'User'
-  boards?: Maybe<Array<TBoard>>
-  email: Scalars['String']
-  followeeStatus?: Scalars['Boolean']
-  followeesCount?: Scalars['Int']
-  followingStatus?: Scalars['Boolean']
-  followingsCount?: Scalars['Int']
-  id: Scalars['String']
-  intro?: Maybe<Scalars['String']>
-  jobGroup?: Scalars['String']
-  like?: Maybe<Array<TBoard>>
-  nickName: Scalars['String']
-  picture?: Maybe<Scalars['String']>
-  provider?: Scalars['String']
-  snsAccounts?: Maybe<Array<TSnsAccount>>
-}
+  __typename?: 'User';
+  boards?: Maybe<Array<TBoard>>;
+  email: Scalars['String'];
+  followeeStatus: Scalars['Boolean'];
+  followeesCount: Scalars['Int'];
+  followingStatus: Scalars['Boolean'];
+  followingsCount: Scalars['Int'];
+  id: Scalars['String'];
+  intro?: Maybe<Scalars['String']>;
+  jobGroup: Scalars['String'];
+  like?: Maybe<Array<TBoard>>;
+  nickName: Scalars['String'];
+  picture?: Maybe<Scalars['String']>;
+  provider: Scalars['String'];
+  snsAccounts?: Maybe<Array<TSnsAccount>>;
+};
 
 export type TYoutube = {
-  __typename?: 'Youtube'
-  thumbnailUrl: Scalars['String']
-  title: Scalars['String']
-  videoUrl: Scalars['String']
-  views: Scalars['Float']
-}
+  __typename?: 'Youtube';
+  thumbnailUrl: Scalars['String'];
+  title: Scalars['String'];
+  videoUrl: Scalars['String'];
+  views: Scalars['Float'];
+};

--- a/desk/src/commons/types/generated/types.ts
+++ b/desk/src/commons/types/generated/types.ts
@@ -41,7 +41,7 @@ export type TComments = {
   __typename?: 'Comments';
   board: TBoard;
   content: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  createdAt?: Maybe<Scalars['DateTime']>;
   id: Scalars['String'];
   replies?: Maybe<Array<TReply>>;
   user: TUser;
@@ -262,10 +262,11 @@ export type TQuery = {
 
 export type TQueryFetchBoardArgs = {
   boardid: Scalars['String'];
+  userid: Scalars['String'];
 };
 
 
-export type TQueryFetchBoardsUserLikedArgs = {
+export type TQueryFetchBoardsArgs = {
   userid: Scalars['String'];
 };
 
@@ -276,6 +277,11 @@ export type TQueryFetchFolloweesArgs = {
 
 
 export type TQueryFetchFollowingsArgs = {
+  userid: Scalars['String'];
+};
+
+
+export type TQueryFetchTop10Args = {
   userid: Scalars['String'];
 };
 
@@ -347,7 +353,7 @@ export type TUpdateUserInput = {
   jobGroup?: InputMaybe<Scalars['String']>;
   nickName?: InputMaybe<Scalars['String']>;
   picture?: InputMaybe<Scalars['String']>;
-  snsAccount?: InputMaybe<Scalars['String']>;
+  snsAccount?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type TUser = {

--- a/desk/src/components/ui/customSkeleton/index.tsx
+++ b/desk/src/components/ui/customSkeleton/index.tsx
@@ -1,0 +1,12 @@
+import { Skeleton, SkeletonCircle, SkeletonText } from '@chakra-ui/react'
+
+export default function CustomSkeleton() {
+  return (
+    <>
+      <Skeleton h="260px">
+        <div>contents wrapped</div>
+        <div>wont be visible</div>
+      </Skeleton>
+    </>
+  )
+}

--- a/desk/src/components/units/main/categories/allProducts/AllProducts.presenter.tsx
+++ b/desk/src/components/units/main/categories/allProducts/AllProducts.presenter.tsx
@@ -1,4 +1,4 @@
-import { Box, Center } from '@chakra-ui/react'
+import { Box, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import { AllProductsUIProps } from './AllProducts.types'
 import CategoryHeader from '../../components/categoryHeader/CategoryHeader.container'
 import MainProductItems from '../../components/mainProductItems'
@@ -7,6 +7,8 @@ import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 
 export default function AllProductsUI(props: AllProductsUIProps) {
+  const [isMobile] = useMediaQuery('(max-width: 768px)')
+
   const settings = {
     dots: false,
     infinite: true,
@@ -26,16 +28,38 @@ export default function AllProductsUI(props: AllProductsUIProps) {
       />
       <Center>
         <Box maxWidth="1100px">
-          <Slider {...settings}>
-            {props.allProducts.map((product, index) => (
-              <Box key={index} p="0px 10px" textAlign="center">
-                <MainProductItems
-                  title={product.name ?? ''}
-                  image={product.picture ?? ''}
-                />
-              </Box>
-            ))}
-          </Slider>
+          {isMobile ? (
+            <Flex
+              direction="row"
+              overflowX="auto"
+              w="410px"
+              css={{
+                '&::-webkit-scrollbar': {
+                  display: 'none',
+                },
+                scrollbarWidth: 'none',
+              }}>
+              {props.allProducts.map((product, index) => (
+                <Box key={index} textAlign="center">
+                  <MainProductItems
+                    title={product.name ?? ''}
+                    image={product.picture ?? ''}
+                  />
+                </Box>
+              ))}
+            </Flex>
+          ) : (
+            <Slider {...settings}>
+              {props.allProducts.map((product, index) => (
+                <Box key={index} p="0px 10px" textAlign="center">
+                  <MainProductItems
+                    title={product.name ?? ''}
+                    image={product.picture ?? ''}
+                  />
+                </Box>
+              ))}
+            </Slider>
+          )}
         </Box>
       </Center>
     </>

--- a/desk/src/components/units/main/categories/best/Best.container.tsx
+++ b/desk/src/components/units/main/categories/best/Best.container.tsx
@@ -6,7 +6,9 @@ import CustomSpinner from '@/src/components/ui/customSpinner'
 import ErrorMessage from '@/src/components/ui/errorMessage'
 
 export default function Best() {
-  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchTop10'>>(FETCH_TOP10)
+  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchTop10'>>(FETCH_TOP10, {
+    variables: { userid: '' },
+  })
 
   if (loading) {
     return <CustomSpinner />

--- a/desk/src/components/units/main/categories/best/Best.queries.ts
+++ b/desk/src/components/units/main/categories/best/Best.queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_TOP10 = gql`
-  query fetchTop10 {
-    fetchTop10 {
+  query fetchTop10($userid: String!) {
+    fetchTop10(userid: $userid) {
       id
       title
       pictures {

--- a/desk/src/components/units/main/categories/followingBoards/followingBoards.container.tsx
+++ b/desk/src/components/units/main/categories/followingBoards/followingBoards.container.tsx
@@ -19,7 +19,7 @@ export default function FollowingBoards() {
 
   const categoryTitle = '🧐 팔로우 한 유저들의 책상 구경하기'
 
-  const users = data?.fetchFollowingBoards.flatMap(following => following.users) ?? []
+  const users = data?.fetchFollowingBoards ?? []
 
   const boardData = users.reduce((acc, user) => {
     if (user.boards) {

--- a/desk/src/components/units/main/categories/followingBoards/followingBoards.queries.ts
+++ b/desk/src/components/units/main/categories/followingBoards/followingBoards.queries.ts
@@ -1,29 +1,22 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_FOLLOWING_BOARDS = gql`
-  query fetchFollowingBoards {
+  query {
     fetchFollowingBoards {
-      users {
+      id
+      email
+      nickName
+      picture
+      jobGroup
+      boards {
         id
-        nickName
-        picture
-        followeeStatus
-        boards {
+        title
+        recommend
+        description
+        pictures {
           id
-          title
-          pictures {
-            id
-            url
-            isMain
-          }
-          writer {
-            id
-            nickName
-            picture
-          }
-          createdAt
-          likes
-          views
+          url
+          isMain
         }
       }
     }

--- a/desk/src/components/units/main/categories/recent/Recent.container.tsx
+++ b/desk/src/components/units/main/categories/recent/Recent.container.tsx
@@ -6,7 +6,9 @@ import CustomSpinner from '@/src/components/ui/customSpinner'
 import ErrorMessage from '@/src/components/ui/errorMessage'
 
 export default function Recent() {
-  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS)
+  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS, {
+    variables: { userid: '' },
+  })
 
   if (loading) {
     return <CustomSpinner />

--- a/desk/src/components/units/main/categories/recent/Recent.queries.ts
+++ b/desk/src/components/units/main/categories/recent/Recent.queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_BOARDS = gql`
-  query fetchBoards {
-    fetchBoards {
+  query fetchBoards($userid: String!) {
+    fetchBoards(userid: $userid) {
       id
       title
       pictures {

--- a/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
+++ b/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
@@ -24,7 +24,9 @@ export default function YoutubeUI(props: YoutubeUIProps) {
   const [isMobile] = useMediaQuery('(max-width: 768px)')
 
   const getTitleSubstringLength = () => {
-    if (isMobile) return 25
+    if (isMobile) {
+      return 25
+    }
     return 30
   }
 

--- a/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
+++ b/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
@@ -23,6 +23,11 @@ export default function YoutubeUI(props: YoutubeUIProps) {
   const categoryTitle = '유튜브'
   const [isMobile] = useMediaQuery('(max-width: 768px)')
 
+  const getTitleSubstringLength = () => {
+    if (isMobile) return 25
+    return 30
+  }
+
   return (
     <>
       <CategoryHeader categoryTitle={categoryTitle} moreButtonHidden={false} />
@@ -44,8 +49,8 @@ export default function YoutubeUI(props: YoutubeUIProps) {
                   fontWeight="700"
                   color={useColorModeValue('dGray.dark', 'dGray.light')}>
                   <Box>
-                    {youtube.title.substring(0, 30)}
-                    {youtube.title.length > 30 ? '...' : ''}
+                    {youtube.title.substring(0, getTitleSubstringLength())}
+                    {youtube.title.length > getTitleSubstringLength() ? '...' : ''}
                   </Box>
                 </Flex>
                 <Flex
@@ -72,6 +77,7 @@ export default function YoutubeUI(props: YoutubeUIProps) {
           </Box>
         </Center>
       )}
+
       <Modal isOpen={!!props.selectedVideo} onClose={props.onClickCloseModal} size="4xl">
         <ModalOverlay />
         <ModalContent bg={'#000000d1'} borderRadius="10" p="10px">

--- a/desk/src/components/units/main/components/mainBoardSlider/index.tsx
+++ b/desk/src/components/units/main/components/mainBoardSlider/index.tsx
@@ -188,7 +188,7 @@ export default function MainBoardSlider({
 
   return (
     <>
-      <Box position="relative" w="full" h="340px" overflow="hidden">
+      <Box position="relative" w="full" h="350px" overflow="hidden">
         <Box width={{ base: '100%', md: '80%', lg: '1090px' }} mx="auto">
           {isMobile ? (
             <Flex

--- a/desk/src/components/units/main/components/mainBoardSlider/index.tsx
+++ b/desk/src/components/units/main/components/mainBoardSlider/index.tsx
@@ -92,11 +92,14 @@ export default function MainBoardSlider({
 
   const settings = {
     dots: false,
-    // infinite: true,
     infinite: images.length > 4,
     speed: 500,
     slidesToShow: 4.15,
     slidesToScroll: isMobile ? 2 : 4,
+    swipe: isMobile,
+    draggable: isMobile,
+    touchMove: isMobile,
+    swipeToSlide: isMobile,
     beforeChange: (oldIndex: number, newIndex: number) => {
       setCurrentSlide(newIndex)
       setArrowVisible(false)
@@ -120,58 +123,91 @@ export default function MainBoardSlider({
     ],
   }
 
+  const renderContent = () => {
+    return images.map((src, index) => (
+      <Box
+        key={index}
+        p={1}
+        color={useColorModeValue('dGray.dark', 'dGray.light')}
+        w={isMobile ? 'calc(50% -3px)' : 'auto'}
+        mr={isMobile ? '8px' : '0'}
+        mb={isMobile ? '8px' : '0'}
+        flexShrink={0}>
+        <Flex flexDirection="column">
+          <Center
+            pl="5px"
+            mb="5px"
+            onClick={() => onClickBoardDetail(boardIds[index])}
+            cursor="pointer">
+            <MainImageStyle src={src} alt={`Image ${index}`} />
+          </Center>
+          <Center>
+            <Flex flexDirection="column">
+              <Center
+                fontSize={{ base: 'sm', md: 'md' }}
+                fontWeight="bold"
+                textAlign="center"
+                mt={2}
+                w="100%"
+                p="5px"
+                cursor="pointer"
+                onClick={() => onClickBoardDetail(boardIds[index])}
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                  maxWidth: '240px',
+                  margin: '0 auto',
+                  whiteSpace: 'normal',
+                }}>
+                {titles[index] ?? ''}
+              </Center>
+
+              <Center
+                fontSize={{ base: 'xs', md: 'sm' }}
+                w="100%"
+                mt={1}
+                cursor="pointer"
+                onClick={() => onClickUserDetail(userIds[index])}>
+                <Avatar
+                  w="20px"
+                  h="20px"
+                  mr="5px"
+                  src={writerImages[index] ?? 'https://bit.ly/broken-link'}
+                />
+                {writers[index] ?? ''}
+              </Center>
+            </Flex>
+          </Center>
+        </Flex>
+      </Box>
+    ))
+  }
+
   return (
     <>
       <Box position="relative" w="full" h="340px" overflow="hidden">
         <Box width={{ base: '100%', md: '80%', lg: '1090px' }} mx="auto">
-          <Slider {...settings} ref={slider => setSlider(slider)}>
-            {children
-              ? children
-              : images.map((src, index) => (
-                  <Box
-                    key={index}
-                    p={1}
-                    color={useColorModeValue('dGray.dark', 'dGray.light')}>
-                    <Flex flexDirection="column">
-                      <Center
-                        pl="5px"
-                        onClick={() => onClickBoardDetail(boardIds[index])}
-                        cursor="pointer">
-                        <MainImageStyle src={src} alt={`Image ${index}`} />
-                      </Center>
-                      <Center>
-                        <Flex flexDirection="column">
-                          <Center
-                            fontSize={{ base: 'sm', md: 'md' }}
-                            fontWeight="bold"
-                            textAlign="center"
-                            mt={2}
-                            w="100%"
-                            p="0px 10px 0px 10px"
-                            cursor="pointer"
-                            onClick={() => onClickBoardDetail(boardIds[index])}>
-                            {titles[index] ?? ''}
-                          </Center>
-                          <Center
-                            fontSize={{ base: 'xs', md: 'sm' }}
-                            w="100%"
-                            mt={1}
-                            cursor="pointer"
-                            onClick={() => onClickUserDetail(userIds[index])}>
-                            <Avatar
-                              w="20px"
-                              h="20px"
-                              mr="5px"
-                              src={writerImages[index] ?? 'https://bit.ly/broken-link'}
-                            />
-                            {writers[index] ?? ''}
-                          </Center>
-                        </Flex>
-                      </Center>
-                    </Flex>
-                  </Box>
-                ))}
-          </Slider>
+          {isMobile ? (
+            <Flex
+              flexDirection="row"
+              overflowX="scroll"
+              overflowY="hidden"
+              css={{
+                '&::-webkit-scrollbar': {
+                  display: 'none',
+                },
+              }}
+              pr="30px">
+              {renderContent()}
+            </Flex>
+          ) : (
+            <Slider {...settings} ref={slider => setSlider(slider)}>
+              {renderContent()}
+            </Slider>
+          )}
         </Box>
       </Box>
     </>

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -16,9 +16,12 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
+import { useState } from 'react'
 import { SearchBoardsUIProps } from './SearchBoards.types'
 
 export default function SearchBoardsUI(props: SearchBoardsUIProps) {
+  const [showInput, setShowInput] = useState(false)
+
   const onClickSearchButton = () => {
     const searchInput = props.searchInputRef.current
     if (searchInput) {
@@ -40,7 +43,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
     <>
       <Stack spacing={4}>
         <InputGroup>
-          <InputLeftElement pointerEvents="none">
+          <InputLeftElement pointerEvents="auto" onClick={() => setShowInput(!showInput)}>
             <SearchIcon color="dGray.medium" />
           </InputLeftElement>
           <Input
@@ -48,6 +51,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
             placeholder="search"
             focusBorderColor="dPrimary"
             onKeyDown={props.onKeyDown}
+            display={showInput ? 'block' : 'none'}
           />
           <Button
             ml="10px"

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -62,10 +62,16 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
       </Stack>
       <Modal isOpen={props.isOpen} onClose={props.onClose} size="xl">
         <ModalOverlay />
-        <ModalContent>
+        <ModalContent
+          h={
+            props.data?.searchBoards && props.data.searchBoards.length > 0
+              ? '700px'
+              : undefined
+          }
+          p="10px">
           <ModalHeader>검색 결과</ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
+          <ModalBody overflowY="auto">
             {props.data?.searchBoards && props.data.searchBoards.length > 0 ? (
               props.data.searchBoards.map(board => (
                 <Box

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -22,15 +22,16 @@ import { SearchBoardsUIProps } from './SearchBoards.types'
 export default function SearchBoardsUI(props: SearchBoardsUIProps) {
   const [isMobile] = useMediaQuery('(max-width: 480px)')
 
-  const onClickSearchButton = async () => {
+  const onClickSearchButton = () => {
     const searchInput = props.searchInputRef.current
     if (searchInput) {
       const searchValue = searchInput.value
       if (searchValue) {
-        await props.onClickSearchBoard(searchValue)
-        searchInput.value = ''
-        if (!isMobile) {
-          props.onOpen()
+        props.onClickSearchBoard(searchValue)
+        if (isMobile) {
+          props.onSearchOpen()
+        } else {
+          props.onResultOpen()
         }
       }
     }
@@ -38,14 +39,14 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
 
   const onClickBoard = (boardId: string) => {
     props.onClickBoardDetail(boardId)
-    props.onClose()
+    props.onResultClose()
   }
 
-  const handleSearchModalOpen = async () => {
+  const handleSearchModalOpen = () => {
     if (isMobile) {
-      props.onOpen()
+      props.onSearchOpen()
     } else {
-      await onClickSearchButton()
+      onClickSearchButton()
     }
   }
 
@@ -85,7 +86,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
           </Button>
         )}
       </Stack>
-      <Modal isOpen={props.isOpen} onClose={props.onClose} size="xl">
+      <Modal isOpen={props.isResultOpen} onClose={props.onResultClose} size="xl">
         <ModalOverlay />
         <ModalContent
           h={
@@ -126,14 +127,14 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
           <ModalFooter>
             <Button
               _hover={{ bg: 'dPrimaryHover.transparency', color: 'white' }}
-              onClick={props.onClose}>
+              onClick={props.onResultClose}>
               닫기
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
       {isMobile && (
-        <Modal isOpen={props.isOpen} onClose={props.onClose} size="xl">
+        <Modal isOpen={props.isSearchOpen} onClose={props.onSearchClose} size="xl">
           <ModalOverlay />
           <ModalContent p="10px">
             <ModalHeader>검색</ModalHeader>

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -66,7 +66,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
           <ModalHeader>검색 결과</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            {props.data?.searchBoards ? (
+            {props.data?.searchBoards && props.data.searchBoards.length > 0 ? (
               props.data.searchBoards.map(board => (
                 <Box
                   key={board.id}

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -37,17 +37,17 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
     }
   }
 
-  const onClickBoard = (boardId: string) => {
-    props.onClickBoardDetail(boardId)
-    props.onResultClose()
-  }
-
-  const handleSearchModalOpen = () => {
+  const onClickSearchModalOpen = () => {
     if (isMobile) {
       props.onSearchOpen()
     } else {
       onClickSearchButton()
     }
+  }
+
+  const onClickBoard = (boardId: string) => {
+    props.onClickBoardDetail(boardId)
+    props.onResultClose()
   }
 
   return (
@@ -70,7 +70,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
               color="dGray.medium"
               variant="outline"
               _hover={{ color: 'dPrimary', borderColor: 'dPrimary' }}
-              onClick={handleSearchModalOpen}>
+              onClick={onClickSearchModalOpen}>
               검색
             </Button>
           </InputGroup>
@@ -81,7 +81,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
             color="dGray.medium"
             variant="outline"
             _hover={{ color: 'dPrimary', borderColor: 'dPrimary' }}
-            onClick={handleSearchModalOpen}>
+            onClick={onClickSearchModalOpen}>
             <SearchIcon />
           </Button>
         )}

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -15,21 +15,23 @@ import {
   ModalOverlay,
   Stack,
   Text,
+  useMediaQuery,
 } from '@chakra-ui/react'
-import { useState } from 'react'
 import { SearchBoardsUIProps } from './SearchBoards.types'
 
 export default function SearchBoardsUI(props: SearchBoardsUIProps) {
-  const [showInput, setShowInput] = useState(false)
+  const [isMobile] = useMediaQuery('(max-width: 480px)')
 
-  const onClickSearchButton = () => {
+  const onClickSearchButton = async () => {
     const searchInput = props.searchInputRef.current
     if (searchInput) {
       const searchValue = searchInput.value
       if (searchValue) {
-        props.onClickSearchBoard(searchValue)
-        props.onOpen()
+        await props.onClickSearchBoard(searchValue)
         searchInput.value = ''
+        if (!isMobile) {
+          props.onOpen()
+        }
       }
     }
   }
@@ -39,30 +41,49 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
     props.onClose()
   }
 
+  const handleSearchModalOpen = async () => {
+    if (isMobile) {
+      props.onOpen()
+    } else {
+      await onClickSearchButton()
+    }
+  }
+
   return (
     <>
       <Stack spacing={4}>
-        <InputGroup>
-          <InputLeftElement pointerEvents="auto" onClick={() => setShowInput(!showInput)}>
-            <SearchIcon color="dGray.medium" />
-          </InputLeftElement>
-          <Input
-            ref={props.searchInputRef}
-            placeholder="search"
-            focusBorderColor="dPrimary"
-            onKeyDown={props.onKeyDown}
-            display={showInput ? 'block' : 'none'}
-          />
+        {!isMobile && (
+          <InputGroup>
+            <InputLeftElement pointerEvents="none">
+              <SearchIcon color="dGray.medium" />
+            </InputLeftElement>
+            <Input
+              ref={props.searchInputRef}
+              placeholder="search"
+              focusBorderColor="dPrimary"
+              onKeyDown={props.onKeyDown}
+            />
+            <Button
+              ml="10px"
+              borderColor="dGray.medium"
+              color="dGray.medium"
+              variant="outline"
+              _hover={{ color: 'dPrimary', borderColor: 'dPrimary' }}
+              onClick={handleSearchModalOpen}>
+              검색
+            </Button>
+          </InputGroup>
+        )}
+        {isMobile && (
           <Button
-            ml="10px"
             borderColor="dGray.medium"
             color="dGray.medium"
             variant="outline"
             _hover={{ color: 'dPrimary', borderColor: 'dPrimary' }}
-            onClick={onClickSearchButton}>
-            검색
+            onClick={handleSearchModalOpen}>
+            <SearchIcon />
           </Button>
-        </InputGroup>
+        )}
       </Stack>
       <Modal isOpen={props.isOpen} onClose={props.onClose} size="xl">
         <ModalOverlay />
@@ -111,6 +132,37 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
           </ModalFooter>
         </ModalContent>
       </Modal>
+      {isMobile && (
+        <Modal isOpen={props.isOpen} onClose={props.onClose} size="xl">
+          <ModalOverlay />
+          <ModalContent p="10px">
+            <ModalHeader>검색</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              <InputGroup>
+                <InputLeftElement pointerEvents="none">
+                  <SearchIcon color="dGray.medium" />
+                </InputLeftElement>
+                <Input
+                  ref={props.searchInputRef}
+                  placeholder="search"
+                  focusBorderColor="dPrimary"
+                  onKeyDown={props.onKeyDown}
+                />
+                <Button
+                  ml="10px"
+                  borderColor="dGray.medium"
+                  color="dGray.medium"
+                  variant="outline"
+                  _hover={{ color: 'dPrimary', borderColor: 'dPrimary' }}
+                  onClick={onClickSearchButton}>
+                  검색
+                </Button>
+              </InputGroup>
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      )}
     </>
   )
 }

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.types.ts
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.types.ts
@@ -10,7 +10,10 @@ export type SearchBoardsUIProps = {
   highlightSearchKeyword: (text: string, keyword: string) => (string | JSX.Element)[]
   searchInputRef: RefObject<HTMLInputElement>
   searchKeyword?: string
-  isOpen: boolean
-  onOpen: () => void
-  onClose: () => void
+  isSearchOpen: boolean
+  onSearchOpen: () => void
+  onSearchClose: () => void
+  isResultOpen: boolean
+  onResultOpen: () => void
+  onResultClose: () => void
 }

--- a/desk/src/components/units/main/viewMore/allProductsMore/AllProductsMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/allProductsMore/AllProductsMore.presenter.tsx
@@ -1,9 +1,26 @@
-import { Box, Container, Flex, Text, useColorModeValue } from '@chakra-ui/react'
+import {
+  Box,
+  Container,
+  Flex,
+  Text,
+  useBreakpointValue,
+  useColorModeValue,
+} from '@chakra-ui/react'
 import { AllProductsMoreUIProps } from './AllProductsMore.types'
 import InfiniteScroll from 'react-infinite-scroller'
 import MainProductItems from '../../components/mainProductItems'
 
 export default function AllProductsMoreUI(props: AllProductsMoreUIProps) {
+  const categoryTitleFontSize = useBreakpointValue({
+    base: '15pt',
+    md: '18pt',
+  })
+
+  const ml = useBreakpointValue({
+    base: 0,
+    md: '40px',
+  })
+
   return (
     <>
       <Container
@@ -19,8 +36,9 @@ export default function AllProductsMoreUI(props: AllProductsMoreUIProps) {
           'scrollbar-width': 'none',
         }}>
         <Text
-          ml="45px"
-          fontSize="18pt"
+          ml={ml}
+          fontSize={categoryTitleFontSize}
+          textAlign={['center', 'left']}
           fontWeight="700"
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
           💻 전체 장비 모아보기

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.container.tsx
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.container.tsx
@@ -5,10 +5,13 @@ import { ExtendedBoard } from './FollowingBoardsMore.types'
 import { FETCH_FOLLOWING_BOARDS } from './followingBoardsMore.queries'
 import CustomSpinner from '@/src/components/ui/customSpinner'
 import ErrorMessage from '@/src/components/ui/errorMessage'
+import { useRouter } from 'next/router'
 
 export default function FollowingBoardsMore() {
   const { data, loading, error } =
     useQuery<Pick<TQuery, 'fetchFollowingBoards'>>(FETCH_FOLLOWING_BOARDS)
+
+  const router = useRouter()
 
   if (loading) {
     return <CustomSpinner />
@@ -30,9 +33,22 @@ export default function FollowingBoardsMore() {
     console.log('더보기')
   }
 
+  const onClickBoardDetail = (boardId: string) => {
+    router.push(`/boards/${boardId}`)
+  }
+
+  const onClickUserDetail = (userId: string) => {
+    router.push(`/${userId}`)
+  }
+
   return (
     <>
-      <FollowingBoardsMoreUI onLoadMore={handleOnLoadMore} boards={boards} />
+      <FollowingBoardsMoreUI
+        onLoadMore={handleOnLoadMore}
+        boards={boards}
+        onClickBoardDetail={onClickBoardDetail}
+        onClickUserDetail={onClickUserDetail}
+      />
     </>
   )
 }

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.container.tsx
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.container.tsx
@@ -1,6 +1,6 @@
 import FollowingBoardsMoreUI from './FollowingBoardsMore.presenter'
 import { useQuery } from '@apollo/client'
-import { TQuery } from '@/src/commons/types/generated/types'
+import { TBoard, TQuery } from '@/src/commons/types/generated/types'
 import { ExtendedBoard } from './FollowingBoardsMore.types'
 import { FETCH_FOLLOWING_BOARDS } from './followingBoardsMore.queries'
 import CustomSpinner from '@/src/components/ui/customSpinner'
@@ -20,14 +20,17 @@ export default function FollowingBoardsMore() {
     return <ErrorMessage message={error.message} />
   }
 
-  const boards =
-    data?.fetchFollowingBoards
-      .flatMap(following =>
-        following.users.flatMap(user =>
-          user.boards?.map(board => ({ ...board, user: user })),
-        ),
-      )
-      ?.filter((board): board is ExtendedBoard => !!board) ?? []
+  const users = data?.fetchFollowingBoards ?? []
+
+  const boards = users.reduce((acc, user) => {
+    if (user.boards) {
+      const userBoards = user.boards
+        .filter((board): board is TBoard => board !== null && board !== undefined)
+        .map(board => ({ ...board, user: user }))
+      return [...acc, ...userBoards]
+    }
+    return acc
+  }, [] as ExtendedBoard[])
 
   const handleOnLoadMore = () => {
     console.log('더보기')

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
@@ -1,9 +1,27 @@
-import { Avatar, Box, Container, Flex, Text, useColorModeValue } from '@chakra-ui/react'
+import {
+  Avatar,
+  Box,
+  Container,
+  Flex,
+  Text,
+  useBreakpointValue,
+  useColorModeValue,
+} from '@chakra-ui/react'
 import { FollowingBoardsMoreUIProps } from './FollowingBoardsMore.types'
 import MainImageStyle from '@/src/components/ui/mainImageStyle'
 import InfiniteScroll from 'react-infinite-scroller'
 
 export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps) {
+  const categoryTitleFontSize = useBreakpointValue({
+    base: '15pt',
+    md: '18pt',
+  })
+
+  const ml = useBreakpointValue({
+    base: 0,
+    md: '25px',
+  })
+
   return (
     <>
       <Container
@@ -19,8 +37,9 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
           'scrollbar-width': 'none',
         }}>
         <Text
-          ml="40px"
-          fontSize="18pt"
+          ml={ml}
+          fontSize={categoryTitleFontSize}
+          textAlign={['center', 'left']}
           fontWeight="700"
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
           🧐 팔로우 한 유저들의 책상 구경하기
@@ -32,28 +51,41 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
           useWindow={false}>
           <Flex flexWrap="wrap" justifyContent="center" m={2}>
             {props.boards.map((board, index) => (
-              <Box key={index} m={'15px'} p={1} textAlign="center">
-                {board.pictures.map(picture => {
-                  if (picture.isMain) {
-                    return (
-                      <MainImageStyle
-                        key={picture.id}
-                        src={picture.url}
-                        alt={`board image ${board.id}`}
-                      />
-                    )
-                  }
-                })}
-                <Text fontWeight="bold" mt={2}>
-                  {board.title}
+              <Box cursor="pointer" key={index} m={'15px'} p={1} textAlign="center">
+                <Box onClick={() => props.onClickBoardDetail(board.id)}>
+                  {board.pictures.map(picture => {
+                    if (picture.isMain) {
+                      return (
+                        <MainImageStyle
+                          key={picture.id}
+                          src={picture.url}
+                          alt={`board image ${board.id}`}
+                        />
+                      )
+                    }
+                  })}
+                </Box>
+                <Text
+                  w="245px"
+                  noOfLines={2}
+                  fontSize="13pt"
+                  fontWeight="bold"
+                  mt={2}
+                  cursor="pointer"
+                  onClick={() => props.onClickBoardDetail(board.id)}>
+                  {board.title.substring(0, 35)}
+                  {board.title.length > 35 ? '...' : ''}
                 </Text>
-                <Flex alignItems="center" justifyContent="center" mt={1}>
+                <Flex
+                  onClick={() => props.onClickUserDetail(board.user.id)}
+                  alignItems="center"
+                  justifyContent="center"
+                  mt={1}>
                   <Avatar
                     w="20px"
                     h="20px"
                     mr="5px"
-                    // src={board.user.picture}
-                    // alt={board.user.nickName}
+                    src={board.user.picture ?? 'https://bit.ly/broken-link'}
                   />
                   {board.user.nickName}
                 </Flex>

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.types.ts
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.types.ts
@@ -6,5 +6,7 @@ export type ExtendedBoard = TBoard & {
 
 export type FollowingBoardsMoreUIProps = {
   onLoadMore: () => void
+  onClickBoardDetail: (boardId: string) => void
+  onClickUserDetail: (userId: string) => void
   boards: ExtendedBoard[]
 }

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/followingBoardsMore.queries.ts
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/followingBoardsMore.queries.ts
@@ -1,26 +1,22 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_FOLLOWING_BOARDS = gql`
-  query fetchFollowingBoards {
+  query {
     fetchFollowingBoards {
-      users {
+      id
+      email
+      nickName
+      picture
+      jobGroup
+      boards {
         id
-        nickName
-        picture
-        boards {
+        title
+        recommend
+        description
+        pictures {
           id
-          title
-          pictures {
-            id
-            url
-            isMain
-          }
-          writer {
-            id
-          }
-          createdAt
-          likes
-          views
+          url
+          isMain
         }
       }
     }

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.container.tsx
@@ -7,7 +7,9 @@ import ErrorMessage from '@/src/components/ui/errorMessage'
 import { useRouter } from 'next/router'
 
 export default function RecentMore() {
-  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS)
+  const { data, loading, error } = useQuery<Pick<TQuery, 'fetchBoards'>>(FETCH_BOARDS, {
+    variables: { userid: '' },
+  })
   const router = useRouter()
 
   if (loading) {

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   Flex,
   Text,
+  useBreakpointValue,
   useColorModeValue,
 } from '@chakra-ui/react'
 import { RecentMoreUIProps } from './RecentMore.types'
@@ -12,6 +13,16 @@ import MainImageStyle from '@/src/components/ui/mainImageStyle'
 import InfiniteScroll from 'react-infinite-scroller'
 
 export default function RecentMoreUI(props: RecentMoreUIProps) {
+  const categoryTitleFontSize = useBreakpointValue({
+    base: '15pt',
+    md: '18pt',
+  })
+
+  const ml = useBreakpointValue({
+    base: 0,
+    md: '25px',
+  })
+
   return (
     <>
       <Container
@@ -27,11 +38,12 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
           'scrollbar-width': 'none',
         }}>
         <Text
-          ml="30px"
-          fontSize="18pt"
+          ml={ml}
+          fontSize={categoryTitleFontSize}
+          textAlign={['center', 'left']}
           fontWeight="700"
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
-          최근 게시물
+          ⏱️ 최근 게시물
         </Text>
         <InfiniteScroll
           pageStart={0}
@@ -71,7 +83,6 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                     cursor="pointer"
                     onClick={() => props.onClickUserDetail(board.writer.id)}>
                     <Avatar
-                      // size={'xs'}
                       w="20px"
                       h="20px"
                       mr="5px"

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.queries.ts
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_BOARDS = gql`
-  query fetchBoards {
-    fetchBoards {
+  query fetchBoards($userid: String!) {
+    fetchBoards(userid: $userid) {
       id
       title
       pictures {


### PR DESCRIPTION
## 메인페이지 / 더보기 페이지 UI 모바일처리
- 전에 주신 의견에 따라 모바일에서는 카테고리 모두 가로스크롤(스와이프)로 게시물을 넘길 수 있도록 수정했습니다. 
   (인기게시물 / 최근게시물 / 팔로우유저 게시물 / 유튜브 / 전체장비 모아보기)
- 검색은 모바일 시에는 input창을 제거하고 아이콘 버튼을 누르면 모달창에 검색창이 뜨도록 수정했습니다. 

## api 변경에 따른 쿼리 수정
- fetchTop10 api 변경 반영
- fetchBoards api 변경 반영
- fetchFollowingBoards api 변경 반영

## 그 외
- 팔로잉 유저 게시물 모아보기 페이지 - 상세페이지 라우터 연결
- CustomSkeleton 컴포넌트 생성
- 검색 결과 없을 때 로직 수정
- 검색 결과 모달창 스크롤 추가
- code generate