### PR TITLE
[QCF-67] 메인 페이지 useAuth 적용

### DIFF
--- a/desk/pages/main/index.tsx
+++ b/desk/pages/main/index.tsx
@@ -5,17 +5,38 @@ import Like from '@/src/components/units/main/categories/like/Like.container'
 import FollowingBoards from '@/src/components/units/main/categories/followingBoards/followingBoards.container'
 import Youtube from '@/src/components/units/main/categories/youtube/Youtube.container'
 import BoardsRegisterButton from '@/src/components/units/main/components/boardsRegisterButton'
+import { useAuth } from '@/src/commons/hooks/useAuth'
 
 export default function MainPage() {
+  const { isLoggedIn, openModal } = useAuth()
+
+  const onClickUnAuth = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!isLoggedIn) {
+      openModal('LOGIN')
+    }
+  }
+
   return (
     <>
       <Best />
       <Recent />
-      {/* <Like /> */}
-      <FollowingBoards />
+      {/* 좋아요 한 게시물은 추가 예정 */}
+      {/* {isLoggedIn && (
+        <div onClick={onClickUnAuth}>
+          <Like />
+        </div>
+      )} */}
+      {isLoggedIn && (
+        <div onClick={onClickUnAuth}>
+          <FollowingBoards />
+        </div>
+      )}
       <Youtube />
       <AllProducts />
-      <BoardsRegisterButton />
+      <div onClick={onClickUnAuth}>
+        <BoardsRegisterButton />
+      </div>
     </>
   )
 }

--- a/desk/src/commons/libraries/layout/header/LayoutHeader.presenter.tsx
+++ b/desk/src/commons/libraries/layout/header/LayoutHeader.presenter.tsx
@@ -73,7 +73,11 @@ export default function LayoutHeaderUI(props: LayoutHeaderUIProps) {
                   <Avatar
                     mr={2}
                     size={'sm'}
-                    src={'https://avatars.dicebear.com/api/male/username.svg'}
+                    src={
+                      isLoggedIn && myUserInfo?.picture
+                        ? myUserInfo.picture
+                        : 'https://avatars.dicebear.com/api/male/username.svg'
+                    }
                   />
                 </MenuButton>
                 <MenuList alignItems={'center'}>
@@ -81,7 +85,11 @@ export default function LayoutHeaderUI(props: LayoutHeaderUIProps) {
                   <Center>
                     <Avatar
                       size={'xl'}
-                      src={'https://avatars.dicebear.com/api/male/username.svg'}
+                      src={
+                        isLoggedIn && myUserInfo?.picture
+                          ? myUserInfo.picture
+                          : 'https://avatars.dicebear.com/api/male/username.svg'
+                      }
                     />
                   </Center>
                   <br />

--- a/desk/src/components/units/main/components/boardsRegisterButton/index.tsx
+++ b/desk/src/components/units/main/components/boardsRegisterButton/index.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
-import { useRouter } from 'next/router'
 import { Button, Container } from '@chakra-ui/react'
 import { BsPencil } from 'react-icons/bs'
+import { useRouter } from 'next/router'
+import { useAuth } from '@/src/commons/hooks/useAuth'
 
 const StyledButton = styled(Button)`
   position: fixed;
@@ -16,9 +17,16 @@ const StyledButton = styled(Button)`
 `
 
 export default function boardsRegisterButton() {
+  const { isLoggedIn, openModal } = useAuth()
   const router = useRouter()
-  const onClickMoveToBoardsRegister = () => {
-    router.push('/boards/register')
+
+  const onClickMoveToBoardsRegister = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!isLoggedIn) {
+      e.preventDefault()
+      openModal('LOGIN')
+    } else {
+      router.push('/boards/register')
+    }
   }
 
   return (

--- a/desk/src/components/units/main/components/mainBoardSlider/index.tsx
+++ b/desk/src/components/units/main/components/mainBoardSlider/index.tsx
@@ -175,7 +175,7 @@ export default function MainBoardSlider({
                   w="20px"
                   h="20px"
                   mr="5px"
-                  src={writerImages[index] ?? 'https://bit.ly/broken-link'}
+                  src={writerImages[index] || 'https://bit.ly/broken-link'}
                 />
                 {writers[index] ?? ''}
               </Center>

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
@@ -85,7 +85,7 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
                     w="20px"
                     h="20px"
                     mr="5px"
-                    src={board.user.picture ?? 'https://bit.ly/broken-link'}
+                    src={board.user.picture || 'https://bit.ly/broken-link'}
                   />
                   {board.user.nickName}
                 </Flex>

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
@@ -86,7 +86,7 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                       w="20px"
                       h="20px"
                       mr="5px"
-                      src={board.writer.picture ?? 'https://bit.ly/broken-link'}
+                      src={board.writer.picture || 'https://bit.ly/broken-link'}
                     />
                     {board.writer.nickName}
                   </Text>


### PR DESCRIPTION
### 작업사항
- 로그인 시 LayoutHeader에 유저 프로필 이미지 추가
- 메인페이지 useAuth 적용
- 글 작성 컴포넌트 useAuth 적용

### 수정사항
- falsy값 처리를 위해 아바타 이미지 연산자 변경