### PR TITLE
[QCF-79] 메인페이지 / 더보기페이지 리팩토링

### DIFF
--- a/desk/src/commons/libraries/layout/footer/LayoutFooter.presenter.tsx
+++ b/desk/src/commons/libraries/layout/footer/LayoutFooter.presenter.tsx
@@ -64,12 +64,11 @@ export default function LayoutFooterUI() {
     <Box
       bg={useColorModeValue('white', 'gray.900')}
       color={useColorModeValue('gray.700', 'gray.200')}
-      mb={2}
-      mt={100}>
+      py={4}
+      mt={12}>
       <Container
         as={Stack}
         maxW={'8xl'}
-        py={4}
         direction={{ base: 'column', md: 'row' }}
         spacing={4}
         justify={{ base: 'center', md: 'space-between' }}

--- a/desk/src/commons/libraries/layout/index.tsx
+++ b/desk/src/commons/libraries/layout/index.tsx
@@ -17,7 +17,7 @@ export default function Layout(props: LayoutProps) {
   return (
     <>
       <LayoutHeader />
-      <div style={{ height: '100%' }}>{props.children}</div>
+      <div style={{ minHeight: 'calc(100vh - 200px)' }}>{props.children}</div>
       <LayoutFooter />
     </>
   )

--- a/desk/src/commons/utils/util.ts
+++ b/desk/src/commons/utils/util.ts
@@ -21,7 +21,6 @@ export function getDateToRelative(value: string) {
 }
 
 // formatNumber - 조회수
-
 export const formatNumber = (number: number): string => {
   return Intl.NumberFormat().format(number)
 }

--- a/desk/src/commons/utils/util.ts
+++ b/desk/src/commons/utils/util.ts
@@ -19,3 +19,9 @@ export function getDateToRelative(value: string) {
 
   return DateTime.fromISO(value).toRelative()
 }
+
+// formatNumber - 조회수
+
+export const formatNumber = (number: number): string => {
+  return Intl.NumberFormat().format(number)
+}

--- a/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
+++ b/desk/src/components/units/main/categories/youtube/Youtube.presenter.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Center,
   Flex,
-  Text,
   useColorModeValue,
   Modal,
   ModalOverlay,
@@ -13,11 +12,11 @@ import {
 } from '@chakra-ui/react'
 import { TYoutube } from '@/src/commons/types/generated/types'
 import { YoutubeUIProps } from './Youtube.types'
-import { FiEye } from 'react-icons/fi'
 import CategoryHeader from '../../components/categoryHeader/CategoryHeader.container'
 import ReactPlayer from 'react-player'
 import YoutubeSlider from '../../components/youtubeSlider'
 import YoutubeImageStyle from '../../components/youtubeImageStyle'
+import { formatNumber } from '@/src/commons/utils/util'
 
 export default function YoutubeUI(props: YoutubeUIProps) {
   const categoryTitle = '유튜브'
@@ -60,10 +59,15 @@ export default function YoutubeUI(props: YoutubeUIProps) {
                   alignItems="center"
                   pr="5px"
                   color={useColorModeValue('#8e9193', 'dGray.light')}
-                  fontWeight="500">
-                  <br />
-                  <FiEye />
-                  <Text ml="5px">{youtube.views} views</Text>
+                  fontWeight="500"></Flex>
+                <Flex
+                  justifyContent="end"
+                  fontSize="10pt"
+                  fontWeight="500"
+                  mr="5px"
+                  mt="5px"
+                  color={useColorModeValue('dGray.dark', 'dGray.light')}>
+                  조회수: {formatNumber(youtube.views)}
                 </Flex>
               </Box>
             ))}

--- a/desk/src/components/units/main/components/categoryHeader/CategoryHeader.presenter.tsx
+++ b/desk/src/components/units/main/components/categoryHeader/CategoryHeader.presenter.tsx
@@ -17,7 +17,12 @@ export default function CategoryHeaderUI(props: CategoryHeaderUIProps) {
         <Text>{props.categoryTitle}</Text>
         {props.moreButtonHidden && (
           <Link href={props.moreButtonLink || '#'}>
-            <Box as="a" cursor="pointer" fontSize="12pt" mt="5px">
+            <Box
+              as="a"
+              cursor="pointer"
+              fontSize="12pt"
+              mt="5px"
+              _hover={{ color: 'dPrimary' }}>
               더보기 {`>`}
             </Box>
           </Link>

--- a/desk/src/components/units/main/components/mainBoardSlider/index.tsx
+++ b/desk/src/components/units/main/components/mainBoardSlider/index.tsx
@@ -30,7 +30,7 @@ export default function MainBoardSlider({
   const [currentSlide, setCurrentSlide] = useState(0)
   const router = useRouter()
 
-  const [isMobile] = useMediaQuery('(max-width: 767px)')
+  const [isMobile] = useMediaQuery('(max-width: 768px)')
 
   const onClickBoardDetail = (boardId: string) => {
     router.push(`/boards/${boardId}`)

--- a/desk/src/components/units/main/components/mainProductItems/index.tsx
+++ b/desk/src/components/units/main/components/mainProductItems/index.tsx
@@ -17,10 +17,10 @@ export default function MainProductItems(props: MainProductItemsProps) {
       <Flex justify={'flex-start'} align={'center'} wrap={'wrap'}>
         <Card w="260px" h="270px" bgColor={useColorModeValue('dGray.light', '#a0a0a01e')}>
           <CardBody borderRadius="lg">
-            <Image h="150px" src={props.image} alt="" />
+            <Image w="100%" h="150px" borderRadius="5px" src={props.image} alt="" />
             <Stack mt="5">
               <Center
-                fontSize="13pt"
+                fontSize="12pt"
                 fontWeight="600"
                 w="220px"
                 color={useColorModeValue('dGray.dark', 'dGray.light')}>

--- a/desk/src/components/units/main/components/mainProductItems/index.tsx
+++ b/desk/src/components/units/main/components/mainProductItems/index.tsx
@@ -15,14 +15,14 @@ export default function MainProductItems(props: MainProductItemsProps) {
   return (
     <VStack align={'flex-start'} m="2">
       <Flex justify={'flex-start'} align={'center'} wrap={'wrap'}>
-        <Card w="260px" h="270px" bgColor={useColorModeValue('dGray.light', '#a0a0a01e')}>
+        <Card w="250px" h="270px" bgColor={useColorModeValue('dGray.light', '#a0a0a01e')}>
           <CardBody borderRadius="lg">
             <Image w="100%" h="150px" borderRadius="5px" src={props.image} alt="" />
             <Stack mt="5">
               <Center
-                fontSize="12pt"
+                w="210px"
                 fontWeight="600"
-                w="220px"
+                fontSize={{ base: 'sm', md: 'md' }}
                 color={useColorModeValue('dGray.dark', 'dGray.light')}>
                 <Box noOfLines={2}>{props.title}</Box>
               </Center>

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.container.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.container.tsx
@@ -80,7 +80,7 @@ export default function SearchBoards() {
   }
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
       event.preventDefault()
       const searchInput = searchInputRef.current
       if (searchInput) {

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.container.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.container.tsx
@@ -4,8 +4,7 @@ import { useLazyQuery } from '@apollo/client'
 import { KeyboardEvent, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { SEARCH_BOARDS } from './SearchBoards.queries'
-import { Text, useDisclosure, useMediaQuery } from '@chakra-ui/react'
-import CustomSpinner from '@/src/components/ui/customSpinner'
+import { Button, Text, useDisclosure, useMediaQuery } from '@chakra-ui/react'
 import ErrorMessage from '@/src/components/ui/errorMessage'
 
 const highlightSearchKeyword = (
@@ -73,7 +72,7 @@ export default function SearchBoards() {
   }, [data, onResultOpen, onSearchClose])
 
   if (loading) {
-    return <CustomSpinner />
+    return <Button isLoading color="dPrimary" variant="outline" />
   }
 
   if (error) {

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -52,7 +52,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
 
   return (
     <>
-      <Stack spacing={4}>
+      <Stack spacing={4} ml="20px">
         {!isMobile && (
           <InputGroup>
             <InputLeftElement pointerEvents="none">
@@ -60,7 +60,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
             </InputLeftElement>
             <Input
               ref={props.searchInputRef}
-              placeholder="search"
+              placeholder="검색어를 입력하세요."
               focusBorderColor="dPrimary"
               onKeyDown={props.onKeyDown}
             />
@@ -146,7 +146,7 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
                 </InputLeftElement>
                 <Input
                   ref={props.searchInputRef}
-                  placeholder="search"
+                  placeholder="검색어를 입력하세요."
                   focusBorderColor="dPrimary"
                   onKeyDown={props.onKeyDown}
                 />

--- a/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
+++ b/desk/src/components/units/main/components/searchBoards/SearchBoards.presenter.tsx
@@ -40,6 +40,11 @@ export default function SearchBoardsUI(props: SearchBoardsUIProps) {
   const onClickSearchModalOpen = () => {
     if (isMobile) {
       props.onSearchOpen()
+      setTimeout(() => {
+        if (props.searchInputRef.current) {
+          props.searchInputRef.current.focus()
+        }
+      }, 0)
     } else {
       onClickSearchButton()
     }

--- a/desk/src/components/units/main/components/youtubeSlider/index.tsx
+++ b/desk/src/components/units/main/components/youtubeSlider/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
-import { Box, Flex, IconButton, Text, useColorModeValue } from '@chakra-ui/react'
-import { FiEye } from 'react-icons/fi'
+import { Box, Flex, IconButton, useColorModeValue } from '@chakra-ui/react'
 import { TYoutube } from '@/src/commons/types/generated/types'
 import { YoutubeSliderProps } from './types'
 import { IoIosArrowDropleftCircle, IoIosArrowDroprightCircle } from 'react-icons/io'
+import { formatNumber } from '@/src/commons/utils/util'
 import YoutubeImageStyle from '@/src/components/units/main/components/youtubeImageStyle'
 import Slider, { CustomArrowProps } from 'react-slick'
 import 'slick-carousel/slick/slick.css'
@@ -106,10 +106,15 @@ export default function YoutubeSlider({
             alignItems="center"
             pr="5px"
             color={useColorModeValue('#8e9193', 'dGray.light')}
-            fontWeight="500">
-            <br />
-            <FiEye />
-            <Text ml="5px">{youtube.views} views</Text>
+            fontWeight="500"></Flex>
+          <Flex
+            justifyContent="end"
+            fontSize="10pt"
+            fontWeight="500"
+            mr="22px"
+            mt="5px"
+            color={useColorModeValue('dGray.dark', 'dGray.light')}>
+            조회수: {formatNumber(youtube.views)}
           </Flex>
         </Box>
       ))}

--- a/desk/src/components/units/main/viewMore/allProductsMore/AllProductsMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/allProductsMore/AllProductsMore.presenter.tsx
@@ -1,30 +1,13 @@
-import {
-  Box,
-  Container,
-  Flex,
-  Text,
-  useBreakpointValue,
-  useColorModeValue,
-} from '@chakra-ui/react'
+import { Box, Container, Flex, Text, useColorModeValue } from '@chakra-ui/react'
 import { AllProductsMoreUIProps } from './AllProductsMore.types'
 import InfiniteScroll from 'react-infinite-scroller'
 import MainProductItems from '../../components/mainProductItems'
 
 export default function AllProductsMoreUI(props: AllProductsMoreUIProps) {
-  const categoryTitleFontSize = useBreakpointValue({
-    base: '15pt',
-    md: '18pt',
-  })
-
-  const ml = useBreakpointValue({
-    base: 0,
-    md: '40px',
-  })
-
   return (
     <>
       <Container
-        maxW="1260px"
+        maxW="1200px"
         h="900px"
         mt="50px"
         overflow="auto"
@@ -36,9 +19,10 @@ export default function AllProductsMoreUI(props: AllProductsMoreUIProps) {
           'scrollbar-width': 'none',
         }}>
         <Text
-          ml={ml}
-          fontSize={categoryTitleFontSize}
-          textAlign={['center', 'left']}
+          ml={'30px'}
+          mb={4}
+          fontSize={{ base: 'lg', md: 'xl' }}
+          textAlign="left"
           fontWeight="700"
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
           💻 전체 장비 모아보기
@@ -50,7 +34,7 @@ export default function AllProductsMoreUI(props: AllProductsMoreUIProps) {
           useWindow={false}>
           <Flex flexWrap="wrap" justifyContent="center" m={2}>
             {props.allProducts.map((product, index) => (
-              <Box key={index} p="10px" textAlign="center">
+              <Box key={index} m="10px" textAlign="center">
                 <MainProductItems
                   title={product.name ?? ''}
                   image={product.picture ?? ''}

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/FollowingBoardsMore.presenter.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Center,
   Container,
   Flex,
   Text,
@@ -12,20 +13,15 @@ import MainImageStyle from '@/src/components/units/main/components/mainImageStyl
 import InfiniteScroll from 'react-infinite-scroller'
 
 export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps) {
-  const categoryTitleFontSize = useBreakpointValue({
-    base: '15pt',
-    md: '18pt',
-  })
-
   const ml = useBreakpointValue({
-    base: 0,
+    base: '30px',
     md: '25px',
   })
 
   return (
     <>
       <Container
-        maxW="1200px"
+        maxW="1170px"
         h="900px"
         mt="50px"
         overflow="auto"
@@ -38,9 +34,10 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
         }}>
         <Text
           ml={ml}
-          fontSize={categoryTitleFontSize}
-          textAlign={['center', 'left']}
+          mb={4}
+          textAlign="left"
           fontWeight="700"
+          fontSize={{ base: 'lg', md: 'xl' }}
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
           🧐 팔로우 한 유저들의 책상 구경하기
         </Text>
@@ -51,8 +48,13 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
           useWindow={false}>
           <Flex flexWrap="wrap" justifyContent="center" m={2}>
             {props.boards.map((board, index) => (
-              <Box cursor="pointer" key={index} m={'15px'} p={1} textAlign="center">
-                <Box onClick={() => props.onClickBoardDetail(board.id)}>
+              <Box
+                key={index}
+                m={'15px'}
+                textAlign="center"
+                maxW={{ base: '40%', md: '25%' }}
+                color={useColorModeValue('dGray.dark', 'dGray.light')}>
+                <Box onClick={() => props.onClickBoardDetail(board.id)} cursor="pointer">
                   {board.pictures.map(picture => {
                     if (picture.isMain) {
                       return (
@@ -67,30 +69,39 @@ export default function FollowingBoardsMoreUI(props: FollowingBoardsMoreUIProps)
                     }
                   })}
                 </Box>
+                <Center>
+                  <Text
+                    mt={2}
+                    w="235px"
+                    noOfLines={2}
+                    fontSize={{ base: 'sm', md: 'md' }}
+                    fontWeight="bold"
+                    cursor="pointer"
+                    onClick={() => props.onClickBoardDetail(board.id)}>
+                    {board.title.substring(0, 35)}
+                    {board.title.length > 35 ? '...' : ''}
+                  </Text>
+                </Center>
+                <Center>
+                  <Text
+                    fontSize={{ base: 'xs', md: 'sm' }}
+                    onClick={() => props.onClickUserDetail(board.user.id)}
+                    mt={2}>
+                    <Avatar
+                      w="20px"
+                      h="20px"
+                      mr="5px"
+                      src={board.user.picture || 'https://bit.ly/broken-link'}
+                    />
+                    {board.user.nickName}
+                  </Text>
+                </Center>
                 <Text
-                  w="245px"
-                  noOfLines={2}
-                  fontSize="13pt"
-                  fontWeight="bold"
-                  mt={2}
-                  cursor="pointer"
-                  onClick={() => props.onClickBoardDetail(board.id)}>
-                  {board.title.substring(0, 35)}
-                  {board.title.length > 35 ? '...' : ''}
-                </Text>
-                <Flex
-                  onClick={() => props.onClickUserDetail(board.user.id)}
-                  alignItems="center"
-                  justifyContent="center"
+                  fontSize={{ base: 'xs', md: 'sm' }}
+                  color={useColorModeValue('#757575', 'dGray.light')}
                   mt={1}>
-                  <Avatar
-                    w="20px"
-                    h="20px"
-                    mr="5px"
-                    src={board.user.picture || 'https://bit.ly/broken-link'}
-                  />
-                  {board.user.nickName}
-                </Flex>
+                  {`조회수: ${board.views}`}
+                </Text>
               </Box>
             ))}
           </Flex>

--- a/desk/src/components/units/main/viewMore/followingBoardsMore/followingBoardsMore.queries.ts
+++ b/desk/src/components/units/main/viewMore/followingBoardsMore/followingBoardsMore.queries.ts
@@ -20,6 +20,7 @@ export const FETCH_FOLLOWING_BOARDS = gql`
         }
         like
         likes
+        views
       }
     }
   }

--- a/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
+++ b/desk/src/components/units/main/viewMore/recentMore/RecentMore.presenter.tsx
@@ -13,13 +13,8 @@ import MainImageStyle from '@/src/components/units/main/components/mainImageStyl
 import InfiniteScroll from 'react-infinite-scroller'
 
 export default function RecentMoreUI(props: RecentMoreUIProps) {
-  const categoryTitleFontSize = useBreakpointValue({
-    base: '15pt',
-    md: '18pt',
-  })
-
   const ml = useBreakpointValue({
-    base: 0,
+    base: '30px',
     md: '25px',
   })
 
@@ -39,9 +34,10 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
         }}>
         <Text
           ml={ml}
-          fontSize={categoryTitleFontSize}
-          textAlign={['center', 'left']}
+          mb={4}
+          textAlign="left"
           fontWeight="700"
+          fontSize={{ base: 'lg', md: 'xl' }}
           color={useColorModeValue('dGray.dark', 'dGray.light')}>
           ⏱️ 최근 게시물
         </Text>
@@ -54,9 +50,10 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
             {props.boards.map((board, index) => (
               <Box
                 key={index}
-                m={'15px'}
-                maxW={{ base: '100%', md: '25%' }}
-                textAlign="center">
+                m="15px"
+                textAlign="center"
+                maxW={{ base: '40%', md: '25%' }}
+                color={useColorModeValue('dGray.dark', 'dGray.light')}>
                 <Box onClick={() => props.onClickBoardDetail(board.id)} cursor="pointer">
                   <MainImageStyle
                     src={board.pictures.find(picture => picture.isMain)?.url ?? ''}
@@ -68,11 +65,11 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                 </Box>
                 <Center>
                   <Text
+                    mt={2}
                     w="235px"
                     noOfLines={2}
-                    fontSize="13pt"
+                    fontSize={{ base: 'sm', md: 'md' }}
                     fontWeight="bold"
-                    mt={2}
                     cursor="pointer"
                     onClick={() => props.onClickBoardDetail(board.id)}>
                     {board.title.substring(0, 35)}
@@ -94,7 +91,10 @@ export default function RecentMoreUI(props: RecentMoreUIProps) {
                     {board.writer.nickName}
                   </Text>
                 </Center>
-                <Text fontSize="sm" mt={1} color="dGray.dark">
+                <Text
+                  fontSize={{ base: 'xs', md: 'sm' }}
+                  color={useColorModeValue('#757575', 'dGray.light')}
+                  mt={1}>
                   {`조회수: ${board.views}`}
                 </Text>
               </Box>

--- a/desk/styles/globalTheme.ts
+++ b/desk/styles/globalTheme.ts
@@ -13,7 +13,7 @@ export const globalTheme = extendTheme({
       500: '#E53E3E',
     },
     dGray: {
-      dark: '#232323B3',
+      dark: '#232323d5',
       medium: '#BABABA',
       light: '#F8F8F8',
     },


### PR DESCRIPTION
### 작업사항

- 검색 입력창 엔터 입력시 키워드 잘리는 버그 수정
- 검색 placeholder 변경, 모바일 시 로고와 검색창 사이 공간 조정
- 검색 버튼 로딩 spinner 변경
- 모바일환경 검색 모달 열릴 때 input창에 오토포커스 추가
- 카테고리 헤더 더보기 hover 컬러 추가
- 유튜브 조회수 UI 변경 - 우측 하단에 작게, "," 추가
- 사용 장비 이미지 사이즈 조정
- 팔로잉 더보기 페이지 / 최근게시물 더보기 페이지 : 모바일에서 가로 2개씩 렌더링 되도록 수정
- 레이아웃 푸터 위치 조정