### PR TITLE
[QCF-94] 유저 페이지 기능 추가, 쿼리 수정

### DIFF
--- a/desk/src/commons/utils/util.ts
+++ b/desk/src/commons/utils/util.ts
@@ -24,3 +24,11 @@ export function getDateToRelative(value: string) {
 export const formatNumber = (number: number): string => {
   return Intl.NumberFormat().format(number)
 }
+
+// 유저 상대 경로 -> 절대 URL
+export const makeAbsoluteUrl = (url: string) => {
+  if (!/^https?:\/\//i.test(url)) {
+    url = `https://${url}`
+  }
+  return url
+}

--- a/desk/src/components/units/user/User.presenter.tsx
+++ b/desk/src/components/units/user/User.presenter.tsx
@@ -15,6 +15,7 @@ import { UserUIProps } from './User.types'
 import NavigationTab from './components/tabs'
 import FollowModal from './components/followModal'
 import { TSnsAccount } from '@/src/commons/types/generated/types'
+import { makeAbsoluteUrl } from '@/src/commons/utils/util'
 
 export default function UserUI(props: UserUIProps) {
   return (
@@ -72,7 +73,7 @@ export default function UserUI(props: UserUIProps) {
                   snsAccount.sns && (
                     <Link
                       key={snsAccount.id}
-                      href={snsAccount.sns}
+                      href={makeAbsoluteUrl(snsAccount.sns)}
                       isExternal
                       color={useColorModeValue('#1e5d97', '#c1daf2')}
                       fontWeight="600">

--- a/desk/src/components/units/user/components/productItem/index.tsx
+++ b/desk/src/components/units/user/components/productItem/index.tsx
@@ -3,14 +3,19 @@ import { Box, Card, CardBody, Image, Text, VStack } from '@chakra-ui/react'
 export type ProductItemProps = {
   index: number
   productId: string
+  boardId: string
   imageUrl: string
   productName: string
+  onClickProductItem: (boardId: string) => void
 }
 
 export default function ProductItem(props: ProductItemProps) {
   return (
     <Box key={props.index}>
-      <Card h="260px">
+      <Card
+        h="260px"
+        cursor="pointer"
+        onClick={() => props.onClickProductItem(props.boardId)}>
         <CardBody>
           <Image
             height={'150px'}

--- a/desk/src/components/units/user/components/tabs/Tabs.queries.ts
+++ b/desk/src/components/units/user/components/tabs/Tabs.queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const FETCH_USER_BOARDS = gql`
-  query fetchUserBoards($userid: String!) {
-    fetchUserBoards(userid: $userid) {
+  query fetchUserBoards($userid: String!, $searchid: String!) {
+    fetchUserBoards(userid: $userid, searchid: $searchid) {
       id
       pictures {
         id

--- a/desk/src/components/units/user/components/tabs/Tabs.queries.ts
+++ b/desk/src/components/units/user/components/tabs/Tabs.queries.ts
@@ -34,6 +34,9 @@ export const FETCH_USER_PRODUCTS = gql`
       id
       name
       picture
+      board {
+        id
+      }
     }
   }
 `

--- a/desk/src/components/units/user/components/tabs/index.tsx
+++ b/desk/src/components/units/user/components/tabs/index.tsx
@@ -15,6 +15,7 @@ import { MdFavoriteBorder } from 'react-icons/md'
 import { BsColumnsGap } from 'react-icons/bs'
 import { AiOutlineLaptop } from 'react-icons/ai'
 import { useAuth } from '@/src/commons/hooks/useAuth'
+import { useRouter } from 'next/router'
 
 const TabID = {
   USER_POSTS: 0,
@@ -31,6 +32,8 @@ export default function NavigationTabs(props: NavigationTabsProps) {
   const [showUserPosts, setShowUserPosts] = useState(true)
   const [showUserProductPosts, setShowUserProductPosts] = useState(false)
   const [showLikedPosts, setShowLikedPosts] = useState(false)
+
+  const router = useRouter()
 
   const { data: userBoards, refetch: refetchUserBoards } = useQuery<
     Pick<TQuery, 'fetchUserBoards'>
@@ -85,6 +88,10 @@ export default function NavigationTabs(props: NavigationTabsProps) {
     [showUserPosts, showUserProductPosts, showLikedPosts],
   )
 
+  const onClickProductItem = (boardId: string) => {
+    router.push(`boards/${boardId}`)
+  }
+
   useEffect(() => {
     if (showUserPosts) {
       setUserData(userBoards?.fetchUserBoards ?? [])
@@ -133,8 +140,10 @@ export default function NavigationTabs(props: NavigationTabsProps) {
                 <ProductItem
                   index={index}
                   productId={item.id}
+                  boardId={item.board?.id}
                   imageUrl={item.picture}
                   productName={item.name}
+                  onClickProductItem={onClickProductItem}
                 />
               ) : (
                 <BoardItem

--- a/desk/src/components/units/user/components/tabs/index.tsx
+++ b/desk/src/components/units/user/components/tabs/index.tsx
@@ -14,6 +14,7 @@ import { TBoard, TPicture, TProduct, TQuery } from '@/src/commons/types/generate
 import { MdFavoriteBorder } from 'react-icons/md'
 import { BsColumnsGap } from 'react-icons/bs'
 import { AiOutlineLaptop } from 'react-icons/ai'
+import { useAuth } from '@/src/commons/hooks/useAuth'
 
 const TabID = {
   USER_POSTS: 0,
@@ -24,6 +25,7 @@ const MY_PAGE_TAB = [BsColumnsGap, AiOutlineLaptop, MdFavoriteBorder]
 const OTHERS_PAGE_TAB = [BsColumnsGap, AiOutlineLaptop]
 
 export default function NavigationTabs(props: NavigationTabsProps) {
+  const { isLoggedIn, myUserInfo } = useAuth()
   const [userData, setUserData] = useState<TBoard[] | TProduct[]>([])
 
   const [showUserPosts, setShowUserPosts] = useState(true)
@@ -32,7 +34,12 @@ export default function NavigationTabs(props: NavigationTabsProps) {
 
   const { data: userBoards, refetch: refetchUserBoards } = useQuery<
     Pick<TQuery, 'fetchUserBoards'>
-  >(FETCH_USER_BOARDS, { variables: { userid: props.userid as string } })
+  >(FETCH_USER_BOARDS, {
+    variables: {
+      userid: isLoggedIn ? myUserInfo?.id || '' : '',
+      searchid: props.userid as string,
+    },
+  })
 
   const { data: userLikedBoards, refetch: refetchUserLikedBoards } = useQuery<
     Pick<TQuery, 'fetchBoardsUserLiked'>


### PR DESCRIPTION
## 작업 사항
- 유저 게시글 (fetchUserBoards) 쿼리 수정 적용
- 유저 sns 계정 링크 상대 경로 -> 절대 경로로 바꿔서 이동하도록 수정
- 장비 모아보기 탭에서 장비 게시글 클릭 시 해당 장비 게시글의 상세페이지로 이동
