### PR TITLE
[QCF-95] 유저, 마이페이지 리팩토링

### DIFF
--- a/desk/src/components/units/accountEdit/AccountEdit.container.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.container.tsx
@@ -6,7 +6,7 @@ import {
   useEditableControls,
   useToast,
 } from '@chakra-ui/react'
-import { useCallback, useRef, useState } from 'react'
+import { ChangeEvent, useCallback, useRef, useState } from 'react'
 import AccountEditUI from './AccountEdit.presenter'
 import {
   AccountEditInputForm,
@@ -66,6 +66,21 @@ export default function AccountEdit() {
   })
 
   const [myJob, setMyJob] = useState('')
+  const [isEdited, setIsEdited] = useState(false)
+
+  const onChangeInputEdited = useCallback(() => {
+    setIsEdited(true)
+  }, [])
+  const onChangeInputNotEdited = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, defaultData: any) => {
+      const { value: InputData } = event.target
+
+      if (defaultData === InputData) {
+        setIsEdited(false)
+      }
+    },
+    [],
+  )
 
   const onChangeFileUrl = useCallback((fileUrl: string, index: number) => {
     console.log(fileUrl)
@@ -84,6 +99,7 @@ export default function AccountEdit() {
         draft[0] = file
       }),
     )
+    onChangeInputEdited()
   }, [])
 
   // 프로필 이미지 버튼
@@ -92,6 +108,14 @@ export default function AccountEdit() {
   const onClickUploadButton = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     fileUploadRef.current?.click()
+  }
+
+  const onChangeKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // 엔터 쳐도 onBlur 속성 실행시킴
+    if (event.key === 'Enter') {
+      event.preventDefault() // onSubmit 막음
+      event.currentTarget.blur()
+    }
   }
 
   const onClickSubmit = async (data: AccountEditInputForm) => {
@@ -183,6 +207,10 @@ export default function AccountEdit() {
       handleSubmit={handleSubmit}
       myJob={myJob}
       setMyJob={setMyJob}
+      isEdited={isEdited}
+      onChangeInputEdited={onChangeInputEdited}
+      onChangeInputNotEdited={onChangeInputNotEdited}
+      onChangeKeyDown={onChangeKeyDown}
     />
   )
 }

--- a/desk/src/components/units/accountEdit/AccountEdit.container.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.container.tsx
@@ -120,21 +120,35 @@ export default function AccountEdit() {
 
   const onClickSubmit = async (data: AccountEditInputForm) => {
     //TODO: Editable로 이동 예정, Toast로 보여줄 예정
+    if (data.nickName.length < 1) {
+      toast({
+        title: '에러',
+        description: '닉네임은 최소 1자 이상 입력해야 합니다.',
+        status: 'error',
+        duration: 2000,
+        position: 'top',
+      })
+      return
+    }
     if (data.nickName.length > 20) {
       toast({
         title: '에러',
         description: '닉네임은 최대 20자까지 입력 가능합니다.',
         status: 'error',
+        duration: 2000,
         position: 'top',
       })
+      return
     }
     if (data.intro.length > 30) {
       toast({
         title: '에러',
         description: '한 줄 소개는 최대 30자까지 입력 가능합니다.',
         status: 'error',
+        duration: 2000,
         position: 'top',
       })
+      return
     }
 
     let fileBeforeUpload = pictureFile
@@ -188,6 +202,7 @@ export default function AccountEdit() {
           title: '에러',
           description: error.message,
           status: 'error',
+          duration: 2000,
           position: 'top',
         })
       }

--- a/desk/src/components/units/accountEdit/AccountEdit.container.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.container.tsx
@@ -2,58 +2,35 @@ import {
   Flex,
   IconButton,
   IconButtonProps,
-  position,
   useColorModeValue,
   useEditableControls,
   useToast,
 } from '@chakra-ui/react'
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import AccountEditUI from './AccountEdit.presenter'
 import {
   AccountEditInputForm,
   AccountEditSchema,
-  ItemLinkType,
   UpdateUserInput,
 } from './AccountEdit.types'
 import { CheckIcon, EditIcon } from '@chakra-ui/icons'
 import { useAuth } from '@/src/commons/hooks/useAuth'
 import { useMutation } from '@apollo/client'
+import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/router'
 import {
   TMutation,
   TMutationUpdateUserArgs,
   TMutationUploadFileArgs,
 } from '@/src/commons/types/generated/types'
 import { UPDATE_USER } from './AccountEdit.queries'
-import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { UPLOAD_FILE } from '../../ui/fileUpload/quries'
-import { useRouter } from 'next/router'
 import { produce } from 'immer'
-
-const SNS_ACCOUNT_LINKS: ItemLinkType[] = [
-  {
-    id: '',
-    link: '',
-  },
-  {
-    id: '',
-    link: '',
-  },
-  {
-    id: '',
-    link: '',
-  },
-]
-
-const SnsLinkCount = {
-  MAX: 3,
-  MIN: 1,
-}
 
 export default function AccountEdit() {
   function EditableControls() {
-    const { isEditing, getSubmitButtonProps, getCancelButtonProps, getEditButtonProps } =
-      useEditableControls()
+    const { isEditing, getSubmitButtonProps, getEditButtonProps } = useEditableControls()
 
     return isEditing ? (
       <Flex justifyContent="center" align="center">
@@ -62,10 +39,6 @@ export default function AccountEdit() {
           icon={<CheckIcon />}
           {...(getSubmitButtonProps() as IconButtonProps)}
         />
-        {/* <IconButton
-          icon={<CloseIcon />}
-          {...(getCancelButtonProps() as IconButtonProps)}
-        /> */}
       </Flex>
     ) : (
       <Flex justifyContent="center" align="center">
@@ -81,13 +54,13 @@ export default function AccountEdit() {
   }
   const router = useRouter()
   const toast = useToast()
-  // const {register, handleSubmit}
+
   const [updateUser] = useMutation<
     Pick<TMutation, 'updateUser'>,
     TMutationUpdateUserArgs
   >(UPDATE_USER)
   const { myUserInfo } = useAuth()
-  const { register, handleSubmit, setValue, trigger } = useForm<AccountEditInputForm>({
+  const { register, handleSubmit } = useForm<AccountEditInputForm>({
     resolver: yupResolver(AccountEditSchema),
     mode: 'onSubmit',
   })
@@ -113,46 +86,12 @@ export default function AccountEdit() {
     )
   }, [])
 
-  // sns 계정 추가하기
-  const nextId = useRef(SnsLinkCount.MIN)
-  const [snsLinks, setSnsLinks] = useState<ItemLinkType[]>(SNS_ACCOUNT_LINKS)
-
-  const addSnsLink = () => {
-    if (SnsLinkCount.MAX <= snsLinks.length) {
-      return
-    }
-
-    nextId.current += 1
-    // setSnsLinks(prev => [...prev, { id: nextId.current, link: '' }])
-  }
-
-  const deleteSnsLink = (id: number) => () => {
-    // if(SnsLinkCount.MIN = snsLinks.length){
-    //   return
-    // }
-    // setSnsLinks(links => links.filter((link => link.id !== id))
-  }
-
-  const onChangeLink = (event: ChangeEvent<HTMLInputElement>) => {
-    const { id, value } = event.target
-    // setSnsLinks(links =>
-    //   links.map(link => (link.id === Number(id) ? { ...link, link: value } : link)),
-    // )
-  }
-
   // 프로필 이미지 버튼
   const fileUploadRef = useRef<HTMLInputElement>(null)
 
   const onClickUploadButton = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     fileUploadRef.current?.click()
-  }
-
-  // const onChangeMyJob = (myJob: string) => {
-  const onChangeMyJob = () => {
-    setValue('jobGroup', myJob)
-
-    void trigger('jobGroup')
   }
 
   const onClickSubmit = async (data: AccountEditInputForm) => {
@@ -204,17 +143,16 @@ export default function AccountEdit() {
 
           const currentMyJob = myUserInfo?.jobGroup
           const updateUserMyJob = myJob
-
           if (currentMyJob !== updateUserMyJob) {
             updateUserInput.jobGroup = updateUserMyJob
           }
 
           const currentUserNickName = myUserInfo?.nickName
           const updateUserNickName = data.nickName
-
           if (currentUserNickName !== updateUserNickName) {
             updateUserInput.nickName = updateUserNickName
           }
+
           return updateUser({
             variables: { updateUserInput },
           })
@@ -232,28 +170,19 @@ export default function AccountEdit() {
       return
     }
   }
-
   return (
     <AccountEditUI
       myUserInfo={myUserInfo}
       fileUploadRef={fileUploadRef}
-      nextId={nextId}
-      snsLinks={snsLinks}
-      SnsLinkCount={SnsLinkCount}
       EditableControls={EditableControls}
       onChangeFileUrl={onChangeFileUrl}
       onChangeFile={onChangeFile}
-      addSnsLink={addSnsLink}
-      deleteSnsLink={deleteSnsLink}
-      onChangeLink={onChangeLink}
       onClickUploadButton={onClickUploadButton}
       onClickSubmit={onClickSubmit}
-      // useForm={useFormReturn}
       register={register}
       handleSubmit={handleSubmit}
       myJob={myJob}
       setMyJob={setMyJob}
-      // onChangeMyJob={onChangeMyJob}
     />
   )
 }

--- a/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
@@ -71,6 +71,7 @@ export default function AccountEditUI(props: AccountEditUIProps) {
                 defaultValue={props.myUserInfo?.nickName}
                 fontSize="24px"
                 fontWeight="700"
+                onEdit={props.onChangeInputEdited}
                 isPreviewFocusable={false}>
                 <Flex
                   justify={'space-between'}
@@ -81,6 +82,10 @@ export default function AccountEditUI(props: AccountEditUIProps) {
                   <Input
                     {...props.register('nickName')}
                     as={EditableInput}
+                    onBlur={e =>
+                      props.onChangeInputNotEdited(e, props.myUserInfo?.nickName)
+                    }
+                    onKeyDown={props.onChangeKeyDown}
                     focusBorderColor={'dPrimary'}
                   />
                   <props.EditableControls />
@@ -88,7 +93,9 @@ export default function AccountEditUI(props: AccountEditUIProps) {
               </Editable>
               <MyJobSelect
                 setMyJob={props.setMyJob}
+                onChangeInputNotEdited={props.onChangeInputNotEdited}
                 myJob={props.myJob || (props.myUserInfo?.jobGroup as string)}
+                onChangeInputEdited={props.onChangeInputEdited}
               />
             </Box>
           </Flex>
@@ -109,6 +116,7 @@ export default function AccountEditUI(props: AccountEditUIProps) {
                   defaultValue={props.myUserInfo?.intro || ''}
                   fontSize="20px"
                   fontWeight="400"
+                  onEdit={props.onChangeInputEdited}
                   isPreviewFocusable={false}>
                   <Flex
                     justify={'space-between'}
@@ -119,6 +127,10 @@ export default function AccountEditUI(props: AccountEditUIProps) {
                     <Input
                       {...props.register('intro')}
                       as={EditableInput}
+                      onBlur={e =>
+                        props.onChangeInputNotEdited(e, props.myUserInfo?.intro)
+                      }
+                      onKeyDown={props.onChangeKeyDown}
                       focusBorderColor={'dPrimary'}
                     />
                     <props.EditableControls />
@@ -151,7 +163,10 @@ export default function AccountEditUI(props: AccountEditUIProps) {
             </Box>
             <Box w="60%" ml="55px">
               <SnsAccountEdit
+                onChangeInputNotEdited={props.onChangeInputNotEdited}
+                onChangeInputEdited={props.onChangeInputEdited}
                 snsAccounts={props.myUserInfo?.snsAccounts || []}
+                onChangeKeyDown={props.onChangeKeyDown}
                 register={props.register}
               />
             </Box>
@@ -171,7 +186,15 @@ export default function AccountEditUI(props: AccountEditUIProps) {
           </Flex>
         </Flex>
         <Center mt="50px">
-          <Button w="300px" type="submit">
+          <Button
+            w="300px"
+            color={props.isEdited ? '#fff' : '#232323'}
+            backgroundColor={props.isEdited ? 'dPrimary' : ''}
+            // _hover={{ bg: 'dPrimaryHover.dark' }}
+            _hover={
+              props.isEdited ? { bg: 'dPrimaryHover.dark' } : { bg: 'dGray.medium' }
+            }
+            type="submit">
             수정 완료
           </Button>
         </Center>

--- a/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
@@ -119,7 +119,11 @@ export default function AccountEditUI(props: AccountEditUIProps) {
                   fontSize="20px"
                   fontWeight="400"
                   isPreviewFocusable={false}>
-                  <Flex justify={'space-between'} fontSize="18px" fontWeight="400">
+                  <Flex
+                    justify={'space-between'}
+                    align="center"
+                    fontSize="18px"
+                    fontWeight="400">
                     <EditablePreview />
                     <Input
                       {...props.register('intro')}

--- a/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
@@ -188,12 +188,11 @@ export default function AccountEditUI(props: AccountEditUIProps) {
         <Center mt="50px">
           <Button
             w="300px"
-            color={props.isEdited ? '#fff' : '#232323'}
-            backgroundColor={props.isEdited ? 'dPrimary' : ''}
-            // _hover={{ bg: 'dPrimaryHover.dark' }}
-            _hover={
-              props.isEdited ? { bg: 'dPrimaryHover.dark' } : { bg: 'dGray.medium' }
+            color={props.isEdited ? useColorModeValue('#fff', '#1A202C') : '#1A202C'}
+            backgroundColor={
+              props.isEdited ? 'dPrimary' : useColorModeValue('', 'gray.500')
             }
+            _hover={props.isEdited ? { bg: 'dPrimaryHover.dark' } : { bg: 'gray.300' }}
             type="submit">
             수정 완료
           </Button>

--- a/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
+++ b/desk/src/components/units/accountEdit/AccountEdit.presenter.tsx
@@ -1,29 +1,20 @@
-import FileUpload from '@/src/components/ui/fileUpload'
-import SignoutModalButton from '@/src/components/units/accountEdit/components/signoutModalButton'
-import { AddIcon, MinusIcon } from '@chakra-ui/icons'
 import {
   Badge,
   Box,
   Button,
-  ButtonGroup,
   Center,
   Divider,
   Flex,
-  Icon,
-  IconButton,
-  IconButtonProps,
   Input,
-  Link,
   Text,
-  VStack,
   useColorModeValue,
-  useEditableControls,
 } from '@chakra-ui/react'
 import { Editable, EditableInput, EditablePreview } from '@chakra-ui/react'
-
-import { BsLink45Deg } from 'react-icons/bs'
 import { AccountEditUIProps } from './AccountEdit.types'
 import MyJobSelect from '../auth/signup/components/MyJobSelect'
+import SnsAccountEdit from './components/snsAccountEdit'
+import FileUpload from '@/src/components/ui/fileUpload'
+import SignoutModalButton from '@/src/components/units/accountEdit/components/signoutModalButton'
 
 export default function AccountEditUI(props: AccountEditUIProps) {
   return (
@@ -159,96 +150,10 @@ export default function AccountEditUI(props: AccountEditUIProps) {
               </Center>
             </Box>
             <Box w="60%" ml="55px">
-              {/* <Link href="https://www.example.com" isExternal> */}
-              <Flex direction="column" alignItems="stretch" justifyContent="flex-start">
-                {/* <Text fontSize="16px">sns 링크로 이동하기</Text> */}
-                {/* SNS 계정 추가하기 */}
-                <VStack align="stretch">
-                  {props.myUserInfo?.snsAccounts?.map((link, index) => (
-                    <Flex
-                      key={link.id}
-                      direction="row"
-                      justifyContent="space-between"
-                      align="center">
-                      <Flex align="center">
-                        <Icon size="16px" as={BsLink45Deg} mr={1} />
-                        <Link>
-                          <Input
-                            color="##718096"
-                            fontSize="18px"
-                            // TODO: SNS register
-                            {...props.register(`snsAccounts.${index}.link`)}
-                            defaultValue={link.sns || ''}
-                            variant="unstyled"
-                            placeholder="SNS 계정 추가"
-                          />
-                        </Link>
-                      </Flex>
-                    </Flex>
-                  ))}
-
-                  {/* <SnsLinks /> */}
-
-                  {/* {props.snsLinks.map(link => (
-                    <Flex
-                      key={link.id}
-                      direction="row"
-                      justifyContent="space-between"
-                      align="center">
-                      <Flex align="center">
-                        <Icon size="16px" as={BsLink45Deg} mr={1} />
-                        <Link>
-                          <Input
-                            fontSize="18px"
-                            id={`${link.id}`}
-                            // {...props.register('snsAccount')}
-                            variant="unstyled"
-                            placeholder="SNS 계정 추가 (최대 3개)"
-                            onChange={props.onChangeLink}
-                          />
-                        </Link>
-                      </Flex>
-                      {link.id === props.nextId.current ? ( // 추가 될 링크
-                        props.snsLinks.length >= props.SnsLinkCount.MAX ? (
-                          <Button
-                            id={`${link.id}`}
-                            w={'40px'}
-                            h={'40px'}
-                            bgColor={useColorModeValue('dGray.light', '#bababa1e')}
-                            onClick={() => props.deleteSnsLink(link.id)}>
-                            <MinusIcon boxSize={3} />
-                          </Button>
-                        ) : (
-                          <Button
-                            w={'40px'}
-                            h={'40px'}
-                            bgColor={useColorModeValue('dGray.light', '#bababa1e')}
-                            onClick={props.addSnsLink}>
-                            <AddIcon boxSize={3} />
-                          </Button>
-                        )
-                      ) : props.snsLinks.length <= props.SnsLinkCount.MIN ? ( // 기존 링크
-                        <Button
-                          w={'40px'}
-                          h={'40px'}
-                          bgColor={useColorModeValue('dGray.light', '#bababa1e')}
-                          onClick={props.addSnsLink}>
-                          <AddIcon boxSize={3} />
-                        </Button>
-                      ) : (
-                        <Button
-                          id={`${link.id}`}
-                          w={'40px'}
-                          h={'40px'}
-                          bgColor={useColorModeValue('dGray.light', '#bababa1e')}
-                          onClick={() => props.deleteSnsLink(link.id)}>
-                          <MinusIcon boxSize={3} />
-                        </Button>
-                      )}
-                    </Flex>
-                  ))} */}
-                </VStack>
-              </Flex>
+              <SnsAccountEdit
+                snsAccounts={props.myUserInfo?.snsAccounts || []}
+                register={props.register}
+              />
             </Box>
           </Flex>
           <Divider border="1px" borderColor="#bababa" />

--- a/desk/src/components/units/accountEdit/AccountEdit.types.ts
+++ b/desk/src/components/units/accountEdit/AccountEdit.types.ts
@@ -1,8 +1,6 @@
-import { ChangeEvent, MutableRefObject } from 'react'
-// import { TMyUserInfo } from '../auth/Auth.types'
 import * as yup from 'yup'
-import { UseFormReturn, useForm } from 'react-hook-form'
-import { TSnsAccount, TUser } from '@/src/commons/types/generated/types'
+import { UseFormReturn } from 'react-hook-form'
+import { TUser } from '@/src/commons/types/generated/types'
 
 //sns 계정 추가 타입
 export type ItemLinkType = {
@@ -13,44 +11,23 @@ export type ItemLinkType = {
 export type AccountEditUIProps = {
   myUserInfo: TUser | null
   fileUploadRef: React.RefObject<HTMLInputElement>
-  nextId: MutableRefObject<number>
-  snsLinks: Array<ItemLinkType> | undefined
-  SnsLinkCount: {
-    MAX: number
-    MIN: number
-  }
   EditableControls: React.FC // type: JSX.Element | null
   onChangeFileUrl: (fileUrl: string, index: number) => void
   onChangeFile: (file: File, index: number) => void
-  addSnsLink: () => void
-  deleteSnsLink: (id: number) => void
-  onChangeLink: (event: ChangeEvent<HTMLInputElement>) => void
   onClickUploadButton: (e: React.MouseEvent<HTMLButtonElement>) => void
   onClickSubmit: (data: AccountEditInputForm) => void
-  // register: ReturnType<typeof useForm>['register']
-  // handleSubmit: ReturnType<typeof useForm>['handleSubmit']
-  // useForm: UseFormReturn<AccountEditInputForm, any>
-  // useForm: UseFormReturn<AccountEditInputForm, any>
   register: UseFormReturn<AccountEditInputForm, any>['register']
   handleSubmit: UseFormReturn<AccountEditInputForm, any>['handleSubmit']
   myJob: string
   setMyJob: (myJob: string) => void
-  // onChangeMyJob: () => () => void
-  // onChangeMyJob: (myJob: string) => () => void
 }
 
 export type AccountEditInputForm = {
   nickName: string
   intro: string
   picture: string
-  // TODO: 이걸로 변경 예정
   snsAccounts: ItemLinkType[]
-  // snsAccount: {
-  //   id: string
-  //   sns: string
-  // }
   jobGroup: string
-  // snsAccount: string
 }
 
 export type UpdateUserInput = {

--- a/desk/src/components/units/accountEdit/AccountEdit.types.ts
+++ b/desk/src/components/units/accountEdit/AccountEdit.types.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup'
 import { UseFormReturn } from 'react-hook-form'
 import { TUser } from '@/src/commons/types/generated/types'
+import { ChangeEvent } from 'react'
 
 //sns 계정 추가 타입
 export type ItemLinkType = {
@@ -20,6 +21,10 @@ export type AccountEditUIProps = {
   handleSubmit: UseFormReturn<AccountEditInputForm, any>['handleSubmit']
   myJob: string
   setMyJob: (myJob: string) => void
+  isEdited: boolean
+  onChangeInputEdited: () => void
+  onChangeInputNotEdited: (event: ChangeEvent<HTMLInputElement>, defaultData: any) => void
+  onChangeKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 export type AccountEditInputForm = {

--- a/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
+++ b/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
@@ -46,7 +46,7 @@ export default function SnsAccountEdit(props: SnsAccountEditProps) {
         <VStack align="stretch">
           {snsLinks.map((link, index) => (
             <Flex
-              key={index + 1}
+              key={index}
               direction="row"
               justifyContent="space-between"
               align="center">
@@ -54,14 +54,18 @@ export default function SnsAccountEdit(props: SnsAccountEditProps) {
                 <Icon size="16px" as={BsLink45Deg} mr={1} />
                 <Link>
                   <Input
-                    id={`${index + 1}`}
+                    id={link.id || `${index}`}
                     color="#718096"
                     fontSize="18px"
                     {...props.register(`snsAccounts.${index}.link`)}
                     defaultValue={link.link || ''}
                     variant="unstyled"
+                    onChange={() => props.onChangeInputEdited()}
+                    onBlur={e => props.onChangeInputNotEdited(e, link.link)}
+                    onKeyDown={props.onChangeKeyDown}
                     placeholder="SNS 계정 추가"
                     focusBorderColor="dPrimary"
+                    tabIndex={-1} // Tab 키로 넘어가지 않도록 설정
                   />
                 </Link>
               </Flex>

--- a/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
+++ b/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { Flex, Icon, Input, Link, VStack } from '@chakra-ui/react'
+import { ItemLinkType } from '../../AccountEdit.types'
+import { SnsAccountEditProps } from './types'
+import { BsLink45Deg } from 'react-icons/bs'
+
+const SNS_ACCOUNT_LINKS: ItemLinkType[] = [
+  {
+    id: '',
+    link: '',
+  },
+  {
+    id: '',
+    link: '',
+  },
+  {
+    id: '',
+    link: '',
+  },
+]
+
+export default function SnsAccountEdit(props: SnsAccountEditProps) {
+  const [snsLinks, setSnsLinks] = useState<ItemLinkType[]>(SNS_ACCOUNT_LINKS)
+
+  useEffect(() => {
+    if (props.snsAccounts) {
+      const updatedLinks = SNS_ACCOUNT_LINKS.map((link, index) => {
+        if (props?.snsAccounts[index]) {
+          return {
+            id: props.snsAccounts[index].id,
+            link: props.snsAccounts[index].sns || '',
+          }
+        } else {
+          return link
+        }
+      })
+      setSnsLinks(updatedLinks)
+    }
+  }, [props.snsAccounts])
+
+  return (
+    <>
+      <Flex direction="column" alignItems="stretch" justifyContent="flex-start">
+        <VStack align="stretch">
+          {snsLinks.map((link, index) => (
+            <Flex
+              key={index + 1}
+              direction="row"
+              justifyContent="space-between"
+              align="center">
+              <Flex align="center">
+                <Icon size="16px" as={BsLink45Deg} mr={1} />
+                <Link>
+                  <Input
+                    id={`${index + 1}`}
+                    color="#718096"
+                    fontSize="18px"
+                    {...props.register(`snsAccounts.${index}.link`)}
+                    defaultValue={link.link || ''}
+                    variant="unstyled"
+                    placeholder="SNS 계정 추가"
+                    focusBorderColor="dPrimary"
+                  />
+                </Link>
+              </Flex>
+            </Flex>
+          ))}
+        </VStack>
+      </Flex>
+    </>
+  )
+}

--- a/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
+++ b/desk/src/components/units/accountEdit/components/snsAccountEdit/index.tsx
@@ -4,36 +4,38 @@ import { ItemLinkType } from '../../AccountEdit.types'
 import { SnsAccountEditProps } from './types'
 import { BsLink45Deg } from 'react-icons/bs'
 
-const SNS_ACCOUNT_LINKS: ItemLinkType[] = [
-  {
-    id: '',
-    link: '',
-  },
-  {
-    id: '',
-    link: '',
-  },
-  {
-    id: '',
-    link: '',
-  },
-]
+const SNS_ACCOUNT_LINKS: ItemLinkType[] = Array.from({ length: 3 }, () => ({
+  id: '',
+  link: '',
+}))
 
 export default function SnsAccountEdit(props: SnsAccountEditProps) {
   const [snsLinks, setSnsLinks] = useState<ItemLinkType[]>(SNS_ACCOUNT_LINKS)
 
   useEffect(() => {
+    //TODO: reduce 함수 써서 리팩토링 재시도할 것
     if (props.snsAccounts) {
-      const updatedLinks = SNS_ACCOUNT_LINKS.map((link, index) => {
-        if (props?.snsAccounts[index]) {
-          return {
-            id: props.snsAccounts[index].id,
-            link: props.snsAccounts[index].sns || '',
-          }
-        } else {
-          return link
+      const updatedLinks: ItemLinkType[] = []
+
+      for (let i = 0; i < props.snsAccounts.length; i++) {
+        const snsAccount = props.snsAccounts[i]
+
+        if (snsAccount.sns !== '') {
+          updatedLinks.push({
+            id: snsAccount.id,
+            link: snsAccount.sns,
+          })
         }
-      })
+
+        if (updatedLinks.length === 3) {
+          break
+        }
+      }
+
+      while (updatedLinks.length < 3) {
+        updatedLinks.push({ id: '', link: '' })
+      }
+
       setSnsLinks(updatedLinks)
     }
   }, [props.snsAccounts])

--- a/desk/src/components/units/accountEdit/components/snsAccountEdit/types.ts
+++ b/desk/src/components/units/accountEdit/components/snsAccountEdit/types.ts
@@ -1,5 +1,6 @@
 import { UseFormReturn } from 'react-hook-form'
 import { AccountEditInputForm } from '../../AccountEdit.types'
+import { ChangeEvent } from 'react'
 
 export type SnsAccountsType = {
   id: string
@@ -9,4 +10,7 @@ export type SnsAccountsType = {
 export type SnsAccountEditProps = {
   snsAccounts: SnsAccountsType[]
   register: UseFormReturn<AccountEditInputForm, any>['register']
+  onChangeInputEdited: () => void
+  onChangeInputNotEdited: (event: ChangeEvent<HTMLInputElement>, defaultData: any) => void
+  onChangeKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
 }

--- a/desk/src/components/units/accountEdit/components/snsAccountEdit/types.ts
+++ b/desk/src/components/units/accountEdit/components/snsAccountEdit/types.ts
@@ -1,0 +1,12 @@
+import { UseFormReturn } from 'react-hook-form'
+import { AccountEditInputForm } from '../../AccountEdit.types'
+
+export type SnsAccountsType = {
+  id: string
+  sns: string
+}
+
+export type SnsAccountEditProps = {
+  snsAccounts: SnsAccountsType[]
+  register: UseFormReturn<AccountEditInputForm, any>['register']
+}

--- a/desk/src/components/units/auth/Auth.types.ts
+++ b/desk/src/components/units/auth/Auth.types.ts
@@ -1,3 +1,4 @@
+import { ChangeEvent } from 'react'
 import * as yup from 'yup'
 
 export type errMsg = {
@@ -54,6 +55,8 @@ export type MyJob = {
   setMyJob: (myJob: string) => void
   // onChange?: (myJob: string) => void
   onChange?: (myJob: string) => void
+  onChangeInputEdited: () => void
+  onChangeInputNotEdited: (event: ChangeEvent<HTMLInputElement>, defaultData: any) => void
 }
 
 const ErrorLog = {

--- a/desk/src/components/units/auth/queries/mutation.ts
+++ b/desk/src/components/units/auth/queries/mutation.ts
@@ -58,10 +58,10 @@ export const FETCH_LOGIN_USER = gql`
   query {
     fetchLoginUser {
       id
-      email
+      picture
       nickName
       intro
-      picture
+      email
       jobGroup
       provider
       followingsCount

--- a/desk/src/components/units/auth/signup/components/MyJobSelect.tsx
+++ b/desk/src/components/units/auth/signup/components/MyJobSelect.tsx
@@ -21,20 +21,28 @@ export default function MyJobSelect(props: MyJob) {
     }
   }, [props.myJob])
 
+  useEffect(() => {
+    if (defaultValue) {
+      props.setMyJob(selectedMyJob?.shortName || '')
+    }
+  }, [])
+
   const onChangeMySelectJob = (e: ChangeEvent<HTMLSelectElement>) => {
     const { value: shortName } = e.target
+    console.log('onChange 이름', shortName)
     props.setMyJob(shortName)
     setTextColor('')
   }
 
   const selectedMyJob = JOB_LIST.find(job => job.shortName === props.myJob)
+  const defaultValue = selectedMyJob?.shortName ? selectedMyJob?.fullName : ''
 
   return (
     <>
       <Select
         focusBorderColor={'dPrimary'}
         color={textColor}
-        defaultValue={selectedMyJob?.fullName}
+        value={props.myJob || defaultValue}
         placeholder="직군을 선택해 주세요 *"
         onChange={onChangeMySelectJob}
         isRequired>

--- a/desk/src/components/units/auth/signup/components/MyJobSelect.tsx
+++ b/desk/src/components/units/auth/signup/components/MyJobSelect.tsx
@@ -29,9 +29,11 @@ export default function MyJobSelect(props: MyJob) {
 
   const onChangeMySelectJob = (e: ChangeEvent<HTMLSelectElement>) => {
     const { value: shortName } = e.target
-    console.log('onChange 이름', shortName)
     props.setMyJob(shortName)
     setTextColor('')
+    if (shortName !== props.myJob) {
+      props.onChangeInputEdited()
+    }
   }
 
   const selectedMyJob = JOB_LIST.find(job => job.shortName === props.myJob)

--- a/desk/src/components/units/user/User.container.tsx
+++ b/desk/src/components/units/user/User.container.tsx
@@ -19,11 +19,9 @@ import {
 export default function User(props: UserProps) {
   const router = useRouter()
   const toast = useToast()
-
+  const { isLoggedIn, myUserInfo, openModal } = useAuth()
   const [isMyPage, setIsMyPage] = useState(false)
   const [isFollowing, setIsFollowing] = useState<boolean>(false)
-  const { isLoggedIn, myUserInfo, openModal } = useAuth()
-
   const [updateFollowing] = useMutation<
     Pick<TMutation, 'updateFollowing'>,
     TMutationUpdateFollowingArgs
@@ -56,6 +54,29 @@ export default function User(props: UserProps) {
     await Promise.all([refetchFollowees(), refetchFollowings()])
   }
 
+  useEffect(() => {
+    if (myUserInfo?.id === props.userData?.user.id) {
+      setIsMyPage(true)
+    } else {
+      setIsMyPage(false)
+    }
+  }, [myUserInfo?.id, props.userData?.user.id])
+
+  useEffect(() => {
+    const targetId = myUserInfo?.id
+    const targetData = followeesData?.fetchFollowees.find(data => data.id === targetId)
+
+    if (targetData?.followeeStatus) {
+      setIsFollowing(true)
+    }
+
+    refetchFollowData()
+  }, [followeesData, myUserInfo])
+
+  useEffect(() => {
+    refetchFollowData()
+  }, [isFollowing])
+
   const onClickMoveToAccountEdit = useCallback(() => {
     router.push('/accountEdit')
   }, [myUserInfo])
@@ -83,39 +104,16 @@ export default function User(props: UserProps) {
       })
   }
 
-  useEffect(() => {
-    if (myUserInfo?.id === props.userData?.user.id) {
-      setIsMyPage(true)
-    } else {
-      setIsMyPage(false)
-    }
-  }, [myUserInfo?.id, props.userData?.user.id])
-
-  useEffect(() => {
-    const targetId = myUserInfo?.id
-    const targetData = followeesData?.fetchFollowees.find(data => data.id === targetId)
-
-    if (targetData?.followeeStatus) {
-      setIsFollowing(true)
-    }
-
-    refetchFollowData()
-  }, [followeesData, myUserInfo])
-
-  useEffect(() => {
-    refetchFollowData()
-  }, [isFollowing])
-
   return (
     <UserUI
       userData={props.userData}
       isLoggedIn={isLoggedIn}
       isMyPage={isMyPage}
       isFollowing={isFollowing}
-      onClickMoveToAccountEdit={onClickMoveToAccountEdit}
-      onClickFollowingButton={onClickFollowingButton}
       followeesData={followeesData}
       followingsData={followingsData}
+      onClickMoveToAccountEdit={onClickMoveToAccountEdit}
+      onClickFollowingButton={onClickFollowingButton}
     />
   )
 }

--- a/desk/src/components/units/user/User.presenter.tsx
+++ b/desk/src/components/units/user/User.presenter.tsx
@@ -4,18 +4,14 @@ import {
   Box,
   Button,
   Flex,
-  Link,
   Text,
-  Icon,
   useColorModeValue,
 } from '@chakra-ui/react'
 import { GoPencil } from 'react-icons/go'
-import { BsLink45Deg } from 'react-icons/bs'
 import { UserUIProps } from './User.types'
 import NavigationTab from './components/tabs'
 import FollowModal from './components/followModal'
-import { TSnsAccount } from '@/src/commons/types/generated/types'
-import { makeAbsoluteUrl } from '@/src/commons/utils/util'
+import SnsAccount from './components/snsAccount'
 
 export default function UserUI(props: UserUIProps) {
   return (
@@ -67,41 +63,7 @@ export default function UserUI(props: UserUIProps) {
               <Text mb="23px" fontSize="16px" alignItems="center" fontWeight="600">
                 {props.userData.user.intro}
               </Text>
-
-              {props.userData.user.snsAccounts?.map(
-                (snsAccount: TSnsAccount) =>
-                  snsAccount.sns && (
-                    <Link
-                      key={snsAccount.id}
-                      href={makeAbsoluteUrl(snsAccount.sns)}
-                      isExternal
-                      color={useColorModeValue('#1e5d97', '#c1daf2')}
-                      fontWeight="600">
-                      <Flex alignItems="center" justifyContent="flex-start">
-                        <Icon as={BsLink45Deg} mr={1} />
-                        <Text>{snsAccount.sns}</Text>
-                      </Flex>
-                    </Link>
-                  ),
-              )}
-
-              {/* <Link
-                href="https://www.example.com"
-                isExternal
-                color={useColorModeValue('#1e5d97', '#c1daf2')}
-                fontWeight="600">
-                <Flex
-                  flexDirection={'column'}
-                  alignItems="center"
-                  justifyContent="flex-start">
-                  <Flex>
-                    <Icon as={BsLink45Deg} mr={1} />
-                    <Text>sns 링크로 이동하기</Text>
-                  </Flex>
-                  <Text>sns 링크로 이동하기</Text>
-                  <Text>sns 링크로 이동하기</Text>
-                </Flex>
-              </Link> */}
+              <SnsAccount snsAccounts={props.userData?.user.snsAccounts || []} />
             </Flex>
           </Flex>
           <Flex mr="34px" direction="column" justify="center" align="center">
@@ -113,7 +75,7 @@ export default function UserUI(props: UserUIProps) {
               name={props.userData.user.nickName}
               src={props.userData.user.picture ?? 'https://bit.ly/broken-link'}
             />
-            {props.isMyPage ? ( // 나의 페이지면 프로필 수정하기 버튼 / 아니면 팔로우 버튼
+            {props.isMyPage ? (
               <Button
                 alignItems="center"
                 textAlign="center"
@@ -133,7 +95,6 @@ export default function UserUI(props: UserUIProps) {
                 <span style={{ padding: '0 2px' }}>
                   <GoPencil color="dPrimary" />
                 </span>
-                {/* 자신의 페이지일 경우만 보이도록 */}
                 프로필 수정하기
               </Button>
             ) : (
@@ -161,8 +122,6 @@ export default function UserUI(props: UserUIProps) {
             )}
           </Flex>
         </Flex>
-        {/* 게시글, 팔로우, 팔로워 분리 예정 */}
-        {/* TODO:props drilling 최적화 예정 */}
         <NavigationTab isMyPage={props.isMyPage} userid={props.userData.user.id} />
       </Box>
     </Box>

--- a/desk/src/components/units/user/components/followModal/index.tsx
+++ b/desk/src/components/units/user/components/followModal/index.tsx
@@ -36,10 +36,10 @@ import { UPDATE_FOLLOWING } from '../../User.queries'
 import { useEffect, useState } from 'react'
 
 export default function FollowModal(props: FollowModalProps) {
-  const { isOpen, onOpen, onClose } = useDisclosure()
-  const { isLoggedIn, myUserInfo } = useAuth()
   const router = useRouter()
   const toast = useToast()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { isLoggedIn, myUserInfo } = useAuth()
   const [isFollowing, setIsFollowing] = useState(false)
 
   const [updateFollowing] = useMutation<
@@ -68,19 +68,17 @@ export default function FollowModal(props: FollowModalProps) {
     },
   })
 
+  const followings = followingsData?.fetchFollowings ?? [] // 팔로우
+  const followees = followeesData?.fetchFollowees ?? [] // 팔로워
+  const followData = props.type === 'followee' ? followees : followings
+
   const refetchFollowData = async () => {
     await Promise.all([refetchFollowees(), refetchFollowings()])
   }
 
-  const followings = followingsData?.fetchFollowings ?? [] // 팔로우
-  const followees = followeesData?.fetchFollowees ?? [] // 팔로워
-
-  const followData = props.type === 'followee' ? followees : followings
-
-  const onClickModalButton = () => {
-    // 로그인 시 팔로워/팔로우 모달 창 오픈
-    onOpen()
-  }
+  useEffect(() => {
+    refetchFollowData()
+  }, [isFollowing])
 
   const onClickMoveToOtherUserPage = (userid: string) => () => {
     router.push(`/${userid}`)
@@ -109,9 +107,6 @@ export default function FollowModal(props: FollowModalProps) {
         }
       })
   }
-  useEffect(() => {
-    refetchFollowData()
-  }, [isFollowing])
 
   return (
     <>
@@ -120,7 +115,7 @@ export default function FollowModal(props: FollowModalProps) {
         fontWeight="600"
         cursor="pointer"
         _hover={{ bg: 'dGray.light' }}
-        onClick={onClickModalButton}>
+        onClick={() => onOpen()}>
         {props.type === 'followee'
           ? `팔로워 ${followeesData?.fetchFollowees.length ?? 0}`
           : `팔로우 ${followingsData?.fetchFollowings.length ?? 0}`}

--- a/desk/src/components/units/user/components/snsAccount/index.tsx
+++ b/desk/src/components/units/user/components/snsAccount/index.tsx
@@ -1,0 +1,34 @@
+import { TSnsAccount } from '@/src/commons/types/generated/types'
+import { makeAbsoluteUrl } from '@/src/commons/utils/util'
+import { Flex, Icon, Link, Text, useColorModeValue } from '@chakra-ui/react'
+
+import { BsLink45Deg } from 'react-icons/bs'
+
+export type SnsAccountProps = {
+  snsAccounts?: Array<TSnsAccount>
+}
+
+export default function SnsAccount(props: SnsAccountProps) {
+  console.log('sns계쩡', props.snsAccounts)
+  return (
+    <>
+      {props.snsAccounts?.map(
+        snsAccount =>
+          snsAccount.sns && (
+            <Link
+              id={snsAccount.id}
+              key={snsAccount.id}
+              href={makeAbsoluteUrl(snsAccount.sns)}
+              isExternal
+              color={useColorModeValue('#1e5d97', '#c1daf2')}
+              fontWeight="600">
+              <Flex alignItems="center" justifyContent="flex-start">
+                <Icon as={BsLink45Deg} mr={1} />
+                <Text>{snsAccount.sns}</Text>
+              </Flex>
+            </Link>
+          ),
+      )}
+    </>
+  )
+}

--- a/desk/src/components/units/user/components/snsAccount/index.tsx
+++ b/desk/src/components/units/user/components/snsAccount/index.tsx
@@ -9,7 +9,6 @@ export type SnsAccountProps = {
 }
 
 export default function SnsAccount(props: SnsAccountProps) {
-  console.log('sns계쩡', props.snsAccounts)
   return (
     <>
       {props.snsAccounts?.map(


### PR DESCRIPTION
## 작업 사항
- 프로필 수정 페이지 수정완료 버튼 입력에 따라 활성화/비활성화 기능 구현
    - 프로필 정보 수정 안 할 시 비활성화, 수정하면 활성화 되도록 구현
- 수정완료 버튼 다크모드 적용
- 닉네임 최소 글자 수 지정(1자 이상), 에러 메세지 지속시간 단축(2초)

## 수정 사항
- User.Container 코드 리팩토링
- 팔로우 모달 코드 리팩토링
- NavigationTab 코드 리팩토링
- JobSelect 기본 값 설정 버그 수정
- 한 줄 소개 버그 수정
- snsAccount, snsAccountEdit 파일 분리
- sns계정 버그 수정
